### PR TITLE
Feat/Update Word Service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .env
+*.pyc
+settings.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,33 @@
-# v.0.1.1
+# Changelog
 
----
+All notable changes to this project will be documented in this file.
 
-- [x] Add `Dockerfile` in `backend` workspace
-- [x] Add `docker-compose` in `backend` workspace
-- [x] Add `main.py` in `backend` workspace
-- [x] Add `models.py` in `backend` workspace
-- [x] Add `database.py` in `backend` workspace
-- [x] Add `schemas.py` in `backend` workspace
-- [x] Add `tests` module in `backend` workspace
-- [x] Add `frontend` workspace
-- [x] Refactor `page.tsx` by adding basic home page
-- [x] Add `word.ts` for backend connectivity
-- [x] Add `WordTable.tsx` React component for word table visualisation
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] - 2026-03-02
+
+### Added
+
+- **Backend**: New `PUT /words/{word_id}` endpoint in `main.py` to support word updates.
+- **Backend**: `WordUpdate` Pydantic schema to allow partial updates of vocabulary entries.
+- **Tests**: Functional test suite `test_update_word_success` covering the update logic.
+
+### Changed
+
+- **Backend**: Enhanced `update_word` service logic to prevent null or empty strings for core fields (`word`, `translation`) while allowing partial updates of other attributes.
+
+## [0.1.1] - 2026-02-26
+
+### Added
+
+- **Infrastructure**: Dockerization of the backend using `Dockerfile` and `docker-compose` for local development.
+- **Backend**: Core API architecture including SQLAlchemy `models`, `database` session management, and Pydantic `schemas`.
+- **Backend**: Initial test suite in the `tests` module.
+- **Frontend**: New Next.js workspace with a modular `WordTable` React component.
+- **Frontend**: Type definitions for backend connectivity in `word.ts`.
+
+### Changed
+
+- **Frontend**: Refactored `page.tsx` to integrate with the backend API and display data in the new table component.
+

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ The `pyproject.toml` are organised:
 Commands:
 
 - Install dependency `uv add --package backend <dependency>`
-- Run backend `uv run --package backend uvicorn main:app --reload`
 
 ## Usage
 
@@ -26,7 +25,6 @@ Commands:
 
 The commands for running the docker-compose stack or the tests are inside the `justfile`.
 
-It is important to use:
+### Testing
 
-- `run_backend` starts backend DB and FastAPI service
-- `run_frontend` starts the web app
+It is important to ensure the Database service is running before lunching the testing command.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "backend"
-version = "0.1.1"
+version = "0.2.0"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Simone Porreca", email = "porrecasimone@gmail.com" }]

--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -1,4 +1,4 @@
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 
@@ -27,6 +27,9 @@ def read_root():
 
 @app.post("/words/", response_model=schemas.WordRead)
 def create_word(word: schemas.WordCreate, db: Session = Depends(get_db)):
+    """
+    Create a word in the database and return it.
+    """
     # Create the SQLAlchemy model instance
     db_word = models.Word(**word.model_dump())
 
@@ -38,5 +41,51 @@ def create_word(word: schemas.WordCreate, db: Session = Depends(get_db)):
 
 @app.get("/words/", response_model=list[schemas.WordRead])
 def read_words(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+    """
+    Get all matching words from the database.
+    """
     words = db.query(models.Word).offset(skip).limit(limit).all()
     return words
+
+
+@app.put("/words/{word_id}", response_model=schemas.WordRead)
+def update_word(
+    word_id: int, word_update: schemas.WordUpdate, db: Session = Depends(get_db)
+):
+    """
+    Update an existing word in the database.
+    """
+    # Retrieve word from db to be updated
+    db_word = db.query(models.Word).filter(models.Word.id == word_id).first()
+
+    if not db_word:
+        raise HTTPException(
+            status_code=404, detail=f"🚨 Word with ID {word_id} not found!"
+        )
+
+    # Instance the ORM object from the Pydantic, excluding the unset fields
+    update_data = word_update.model_dump(exclude_unset=True)
+
+    # Check for required fields
+    if "word" in update_data and (
+        update_data["word"] is None or update_data["word"].strip() == ""
+    ):
+        raise HTTPException(
+            status_code=400, detail="🚨 The 'word' field cannot be null or empty."
+        )
+
+    if "translation" in update_data and (
+        update_data["translation"] is None or update_data["translation"].strip() == ""
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail="🚨 The 'translation' field cannot be null or empty.",
+        )
+
+    # Update the fields in the word retrieved from db
+    for key, value in update_data:
+        setattr(db_word, key, value)
+
+    db.commit()
+    db.refresh(db_word)
+    return db_word

--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -83,7 +83,7 @@ def update_word(
         )
 
     # Update the fields in the word retrieved from db
-    for key, value in update_data:
+    for key, value in update_data.items():
         setattr(db_word, key, value)
 
     db.commit()

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -43,5 +43,14 @@ class WordRead(WordBase):
     id: int
     created_at: datetime
 
-    # Tells Pydantic to read SQLAlchemy model attributes
+    # Tells Pydantic to read SQLAlchemy model attributes -> Required when converting DB objects into Pydantic
     model_config = ConfigDict(from_attributes=True)
+
+
+class WordUpdate(WordBase):
+    """
+    Update model: data used to edit a word.
+    """
+
+    word: Optional[str] = None
+    translation: Optional[str] = None

--- a/backend/tests/test_words.py
+++ b/backend/tests/test_words.py
@@ -13,3 +13,17 @@ def test_get_words_list(client):
     response = client.get("/words/")
     assert response.status_code == 200
     assert isinstance(response.json(), list)
+
+
+def test_update_word_success(client, valid_word_payload):
+    # Create word
+    response = client.post("/words/", json=valid_word_payload)
+    word_id = response.json()["id"]
+
+    # Update the category
+    update_payload = {"example_sentences": "Der Zuschlag wurde abgeführt"}
+    response = client.put(f"/words/{word_id}", json=update_payload)
+
+    assert response.status_code == 200
+    assert response.json()["example_sentences"] == "Der Zuschlag wurde abgeführt"
+    assert response.json()["word"] == "Zuschlag"

--- a/backend/tests/test_words.py
+++ b/backend/tests/test_words.py
@@ -15,15 +15,15 @@ def test_get_words_list(client):
     assert isinstance(response.json(), list)
 
 
-def test_update_word_success(client, valid_word_payload):
-    # Create word
-    response = client.post("/words/", json=valid_word_payload)
-    word_id = response.json()["id"]
+# def test_update_word_success(client, valid_word_payload):
+#     # Create word
+#     response = client.post("/words/", json=valid_word_payload)
+#     word_id = response.json()["id"]
 
-    # Update the category
-    update_payload = {"example_sentences": "Der Zuschlag wurde abgeführt"}
-    response = client.put(f"/words/{word_id}", json=update_payload)
+#     # Update the category
+#     update_payload = {"example_sentences": "Der Zuschlag wurde abgeführt"}
+#     response = client.put(f"/words/{word_id}", json=update_payload)
 
-    assert response.status_code == 200
-    assert response.json()["example_sentences"] == "Der Zuschlag wurde abgeführt"
-    assert response.json()["word"] == "Zuschlag"
+#     assert response.status_code == 200
+#     assert response.json()["example_sentences"] == "Der Zuschlag wurde abgeführt"
+#     assert response.json()["word"] == "Zuschlag"

--- a/backend/tests/test_words.py
+++ b/backend/tests/test_words.py
@@ -15,15 +15,15 @@ def test_get_words_list(client):
     assert isinstance(response.json(), list)
 
 
-# def test_update_word_success(client, valid_word_payload):
-#     # Create word
-#     response = client.post("/words/", json=valid_word_payload)
-#     word_id = response.json()["id"]
+def test_update_word_success(client, valid_word_payload):
+    # Create word
+    response = client.post("/words/", json=valid_word_payload)
+    word_id = response.json()["id"]
 
-#     # Update the category
-#     update_payload = {"example_sentences": "Der Zuschlag wurde abgeführt"}
-#     response = client.put(f"/words/{word_id}", json=update_payload)
+    # Update the category
+    update_payload = {"example_sentences": "Der Zuschlag wurde abgeführt"}
+    response = client.put(f"/words/{word_id}", json=update_payload)
 
-#     assert response.status_code == 200
-#     assert response.json()["example_sentences"] == "Der Zuschlag wurde abgeführt"
-#     assert response.json()["word"] == "Zuschlag"
+    assert response.status_code == 200
+    assert response.json()["example_sentences"] == "Der Zuschlag wurde abgeführt"
+    assert response.json()["word"] == "Zuschlag"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT}:5432"
 
   backend:
     build:
@@ -18,7 +18,7 @@ services:
     container_name: vademecum_backend
     environment:
       # We construct the URL using the variables from .env
-      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST_DOCKER}:${POSTGRES_PORT}/${POSTGRES_DB}
     ports:
       - "8000:8000"
     depends_on:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/justfile
+++ b/justfile
@@ -18,6 +18,12 @@ help:
         exit 1; \
     fi
 
+# Run only database
+run_database:
+    docker-compose up -d db
+stop_database:
+    docker-compose stop db
+
 # Docker-compose build -> Create the docker-compose stack
 run_backend: check_root
     docker-compose up --build

--- a/justfile
+++ b/justfile
@@ -30,7 +30,7 @@ run_backend_recreate: check_root
 run_tests: check_root
     # Create docker-compose stack and destroy after finish
     # Run the uv in the "backend" workspace
-    docker-compose run --rm backend uv run --package backend pytest backend/tests
+    docker-compose run --rm --build backend uv run --package backend pytest backend/tests
 
 # Run frontend dev server
 run_frontend: check_root

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vademecum-germanicum"
-version = "0.1.1"
+version = "0.2.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -40,7 +40,7 @@ wheels = [
 
 [[package]]
 name = "backend"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "backend" }
 dependencies = [
     { name = "fastapi" },
@@ -435,5 +435,5 @@ wheels = [
 
 [[package]]
 name = "vademecum-germanicum"
-version = "0.1.0"
+version = "0.1.1"
 source = { virtual = "." }


### PR DESCRIPTION
# Description

The PR resolves the issue #8  by adding a Word Update FastAPI service.

# Changelog

### Added

- **Backend**: New `PUT /words/{word_id}` endpoint in `main.py` to support word updates.
- **Backend**: `WordUpdate` Pydantic schema to allow partial updates of vocabulary entries.
- **Tests**: Functional test suite `test_update_word_success` covering the update logic.

### Changed

- **Backend**: Enhanced `update_word` service logic to prevent null or empty strings for core fields (`word`, `translation`) while allowing partial updates of other attributes.

# Checklist

## Mandatory

- [x] The title of the Pull Request starts with the JIRA ticket number (if provided)
- [x] The title of the Pull Request must reflect the corresponding issue title
- [x] It has to have a `Description` section, specifying which is the `#issue` it's resolving and how
- [x] It has to have a `Changelog` section, reporting what has been changed in the corresponding issue
- [x] The project version must have been updated

## Optional

- [x] Update the Wiki
- [x] Update the `README.md`
- [x] Update the `CHANGELOG.md`
