### PR TITLE
Feat/delete word service

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,18 +1,25 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: ""
+assignees: ""
 ---
 
-# Description
+## Description
+
 As a ...,
 I want to ...,
 In order to ...
 
-# Changelog
+## Changelog
+
+### Added
+
+### Refactor
+
+## Checklist
+
 - [ ] Update Wiki
 - [ ] Update Documentation
 - [ ] Update `CHANGELOG.md`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,24 @@
-# Description
+---
+name: Pull Request
+about: Describe code changes
+title: ""
+labels: ""
+assignees: ""
+---
+
+## Description
 
 The PR resolves the issue #<issue_number> by ...
 
-# Changelog
+## Changelog
 
-- [x] Files Changed
+###  Added
 
-# Checklist
+### Changed
 
-## Mandatory
+## Checklist
+
+### Mandatory
 
 - [x] The title of the Pull Request starts with the JIRA ticket number (if provided)
 - [x] The title of the Pull Request must reflect the corresponding issue title
@@ -16,7 +26,7 @@ The PR resolves the issue #<issue_number> by ...
 - [x] It has to have a `Changelog` section, reporting what has been changed in the corresponding issue
 - [x] The project version must have been updated
 
-## Optional
+### Optional
 
 - [x] Update the Wiki
 - [x] Update the `README.md`

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+  "MD013": false,
+  "MD024": {
+    "siblings_only": true
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-03-05
+
+### Added
+
+- **Backend**: New `DELETE /words/{word_id}` endpoint in `main.py` to support word deletion.
+- **Tests**: Functional test suite `test_update_word_not_found` covering the update exception logic.
+- **Tests**: Functional test suite `test_delete_word_success` covering the deletion logic.
+- **Tests**: Functional test suite `test_delete_word_not_found` covering the deletion exception logic.
+
 ## [0.2.0] - 2026-03-02
 
 ### Added
@@ -30,4 +39,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Frontend**: Refactored `page.tsx` to integrate with the backend API and display data in the new table component.
-

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "backend"
-version = "0.2.0"
+version = "0.2.1"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Simone Porreca", email = "porrecasimone@gmail.com" }]

--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -89,3 +89,26 @@ def update_word(
     db.commit()
     db.refresh(db_word)
     return db_word
+
+
+@app.delete("/words/{word_id}", status_code=204)
+def delete_word(word_id: int, db: Session = Depends(get_db)):
+    """
+    Remove a word from the database by its ID.
+    """
+
+    # Retrieve word from db to be deleted
+    db_word = db.query(models.Word).filter(models.Word.id == word_id).first()
+
+    # Check if word is in the db
+    if not db_word:
+        raise HTTPException(
+            status_code=404, detail=f"🚨 Word with ID {word_id} not found!"
+        )
+
+    # Delete word and commit
+    db.delete(db_word)
+    db.commit()
+
+    # Returning None with status 204 is standard for a successful DELETE
+    return None

--- a/backend/tests/test_words.py
+++ b/backend/tests/test_words.py
@@ -4,18 +4,27 @@ Tests backend word read/creation.
 
 
 def test_create_word_success(client, valid_word_payload):
+    """
+    Ensure the word is created correctly.
+    """
     response = client.post("/words/", json=valid_word_payload)
     assert response.status_code == 200
     assert response.json()["word"] == "Zuschlag"
 
 
 def test_get_words_list(client):
+    """
+    Ensure words are retrieved.
+    """
     response = client.get("/words/")
     assert response.status_code == 200
     assert isinstance(response.json(), list)
 
 
 def test_update_word_success(client, valid_word_payload):
+    """
+    Ensure the word is correctly updated.
+    """
     # Create word
     response = client.post("/words/", json=valid_word_payload)
     word_id = response.json()["id"]
@@ -27,3 +36,38 @@ def test_update_word_success(client, valid_word_payload):
     assert response.status_code == 200
     assert response.json()["example_sentences"] == "Der Zuschlag wurde abgeführt"
     assert response.json()["word"] == "Zuschlag"
+
+
+def test_update_word_not_found(client):
+    """
+    Ensure the status code 404 is returned.
+    """
+    response = client.put("/words/9999", json={})
+    assert response.status_code == 404
+
+
+def test_delete_word_success(client, valid_word_payload):
+    """
+    Esnture the word is correctly deleted.
+    """
+
+    # Create word
+    response = client.post("/words/", json=valid_word_payload)
+    word_id = response.json()["id"]
+
+    # Delete word
+    response = client.delete(f"/words/{word_id}")
+    assert response.status_code == 204
+
+    # Ensure word is not present anymore in db
+    response = client.get("/words/")
+    words = response.json()
+    assert not any(word["id"] == word_id for word in words)
+
+
+def test_delete_word_not_found(client):
+    """
+    Ensure the status code 404 is returned.
+    """
+    response = client.delete("/words/9999")
+    assert response.status_code == 404

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vademecum-germanicum"
-version = "0.2.0"
+version = "0.2.1"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Description

The PR resolves the issue #10  by adding a DELETE FastAPI service.

## Changelog

### Added

- **Backend**: New `DELETE /words/{word_id}` endpoint in `main.py` to support word deletion.
- **Tests**: Functional test suite `test_update_word_not_found` covering the update exception logic.
- **Tests**: Functional test suite `test_delete_word_success` covering the deletion logic.
- **Tests**: Functional test suite `test_delete_word_not_found` covering the deletion exception logic.

## Checklist

### Mandatory

- [x] The title of the Pull Request starts with the JIRA ticket number (if provided)
- [x] The title of the Pull Request must reflect the corresponding issue title
- [x] It has to have a `Description` section, specifying which is the `#issue` it's resolving and how
- [x] It has to have a `Changelog` section, reporting what has been changed in the corresponding issue
- [x] The project version must have been updated

### Optional

- [x] Update the Wiki
- [x] Update the `README.md`
- [x] Update the `CHANGELOG.md`
