### PR TITLE
Feat/29 palette dark mode refinement

### DIFF
--- a/.claude/planning/2-improve-ui/29-palette-dark-mode-refinement.md
+++ b/.claude/planning/2-improve-ui/29-palette-dark-mode-refinement.md
@@ -1,0 +1,160 @@
+# #29: Palette & Dark Mode Refinement
+
+**GitHub Issue:** [#29 — Palette & Dark Mode Refinement](https://github.com/Volscente/vademecum-germanicum/issues/29)
+**GitHub Milestone:** [Milestone: Improve UI](https://github.com/Volscente/vademecum-germanicum/milestone/4)
+**Notion page:** [2 — Improve UI](https://www.notion.so/2-Improve-UI-3575cc6c0f078023834df02a2390b410)
+
+---
+
+## Technical Scope
+
+**In scope:**
+
+- `frontend/src/app/globals.css` — audit; likely no token value changes needed (scale is correct), but the `--background`/`--foreground` `.dark` overrides may be supplemented
+- `frontend/src/app/page.tsx` — remap `dark:text-forest-300` (subtitle) and `dark:text-forest-400` (loading/empty text)
+- `frontend/src/components/WordTable.tsx` — remap `dark:text-forest-300` (word, translation), `dark:text-forest-500` (gender, date), `dark:text-forest-200` (category label), `dark:ring-forest-400/20` (category badge ring)
+- `frontend/src/components/ThemeToggle.tsx` — remap `dark:text-forest-300` (icon colour)
+- `frontend/src/components/AddWordModal.tsx` — remap `dark:text-forest-200` (form labels), `dark:text-forest-300` (cancel button)
+- `frontend/src/components/SearchBar.tsx` — remap `dark:text-forest-500` (search icon, placeholder, clear button), `dark:group-focus-within:text-forest-400` (focus icon)
+
+**Out of scope:**
+
+- Light-mode token values — must not change
+- `forest-*` token definitions in `@theme inline` — the scale itself (`forest-50` through `forest-900`) is correct and stays unchanged
+- Backend code
+- Component layout, spacing, or functional behaviour
+
+---
+
+## Architecture
+
+```txt
+globals.css  (@theme inline: --color-forest-* tokens)
+     │
+     ▼
+.dark class on <html>  (set by layout.tsx inline script before hydration)
+     │                  (toggled at runtime by ThemeToggle.tsx)
+     │
+     ├── page.tsx          dark:text-forest-300 → dark:text-forest-200
+     │                     dark:text-forest-400 → dark:text-forest-300
+     │
+     ├── WordTable.tsx      dark:text-forest-300 → dark:text-forest-200  (word, translation)
+     │                     dark:text-forest-500 → dark:text-forest-400  (gender, date)
+     │                     dark:text-forest-200 → dark:text-forest-100  (category label)
+     │                     dark:ring-forest-400/20 → dark:ring-forest-300/20
+     │
+     ├── ThemeToggle.tsx    dark:text-forest-300 → dark:text-forest-200
+     │
+     ├── AddWordModal.tsx   dark:text-forest-200 → dark:text-forest-100  (form labels)
+     │                     dark:text-forest-300 → dark:text-forest-200  (cancel button)
+     │
+     └── SearchBar.tsx      dark:text-forest-500 → dark:text-forest-400  (icon, placeholder)
+                           dark:group-focus-within:text-forest-400 → dark:group-focus-within:text-forest-300
+                           dark:hover:text-forest-300 → dark:hover:text-forest-200  (clear btn)
+```
+
+### Why shift toward lower (lighter) token numbers in dark mode
+
+In dark mode the page background is `forest-900` (#081c15 — near-black). The mid-range tokens `forest-300` through `forest-500` are saturated green (#95d5b2 – #52b788), which appear as vivid neon against this very dark background. Shifting accent and secondary text toward `forest-100`/`forest-200` (pale, nearly-white with a slight green tint) reduces saturation and produces a muted, sophisticated look while keeping the green identity. Background and structural tokens (`forest-700`–`forest-900`) are already appropriate and are not touched.
+
+---
+
+## Tech Stack
+
+No new packages required.
+
+---
+
+## Implementation Details
+
+### Modules / Files
+
+| File                                          | Action | Description                                          |
+| --------------------------------------------- | ------ | ---------------------------------------------------- |
+| `frontend/src/app/globals.css`                | Reuse  | No change expected; verified during audit            |
+| `frontend/src/app/page.tsx`                   | Edit   | Remap 2 dark-mode text token classes                 |
+| `frontend/src/components/WordTable.tsx`       | Edit   | Remap 4 categories of dark-mode token classes        |
+| `frontend/src/components/ThemeToggle.tsx`     | Edit   | Remap 1 dark-mode icon text class                    |
+| `frontend/src/components/AddWordModal.tsx`    | Edit   | Remap 2 dark-mode text classes (labels, cancel)      |
+| `frontend/src/components/SearchBar.tsx`       | Edit   | Remap 3 dark-mode text classes (icon, placeholder, clear) |
+
+---
+
+### Existing Work (already done)
+
+The flash-of-wrong-theme (FOWT) fix listed in the planning doc as a deliverable of this task is **already implemented** in `frontend/src/app/layout.tsx`:
+
+- An inline `<script dangerouslySetInnerHTML>` reads `localStorage.getItem('theme')` and falls back to `window.matchMedia('(prefers-color-scheme: dark)')`, then sets `document.documentElement.classList` before first paint.
+- `<html suppressHydrationWarning>` is already set.
+
+No changes to `layout.tsx` are needed.
+
+### Gaps to Close
+
+1. Audit each in-scope component for `dark:*` classes in the `forest-200` – `forest-500` range used as foreground text or icon colour.
+2. Apply the token shift rules from the mapping table below.
+3. Manually verify in both light and dark mode that no light-mode class was inadvertently changed.
+
+---
+
+### Token Mapping
+
+The remapping rule is: shift mid-range accent foreground tokens one step lighter (one step closer to `forest-100`) to reduce saturation in dark mode. Structural tokens (backgrounds, dividers, borders) are unchanged.
+
+| Current dark-mode class             | Replacement                           | Used in                                           |
+| ----------------------------------- | ------------------------------------- | ------------------------------------------------- |
+| `dark:text-forest-500`              | `dark:text-forest-400`                | `WordTable` gender/date, `SearchBar` icon/placeholder/clear |
+| `dark:text-forest-400`              | `dark:text-forest-300`                | `page.tsx` loading text, `SearchBar` focus icon   |
+| `dark:text-forest-300`              | `dark:text-forest-200`                | `page.tsx` subtitle, `WordTable` word/translation, `ThemeToggle` icon, `AddWordModal` cancel, `SearchBar` clear hover |
+| `dark:text-forest-200`              | `dark:text-forest-100`                | `WordTable` category label, `AddWordModal` form labels |
+| `dark:ring-forest-400/20`           | `dark:ring-forest-300/20`             | `WordTable` category badge ring                   |
+| `dark:group-focus-within:text-forest-400` | `dark:group-focus-within:text-forest-300` | `SearchBar` search icon on focus           |
+| `dark:hover:text-forest-300`        | `dark:hover:text-forest-200`          | `SearchBar` clear button hover                    |
+| *(missing)* `dark:focus:ring-forest-400` | add alongside `focus:ring-forest-500` | `AddWordModal` and `SearchBar` input focus ring |
+
+Unchanged in dark mode (correct as-is):
+
+| Class pattern                        | Reason                                              |
+| ------------------------------------ | --------------------------------------------------- |
+| `dark:bg-forest-700/800/900`         | Dark backgrounds — appropriate depth                |
+| `dark:border-forest-600/700`         | Structural dividers — already muted                 |
+| `dark:text-forest-100`               | Primary foreground text — correct, stays            |
+| `dark:divide-forest-700`             | Table dividers — correct                            |
+
+---
+
+### Testing Strategy
+
+No automated tests apply — all verification is visual and manual.
+
+**Dark mode verification:**
+
+1. Open the app in a browser and enable dark mode via the `ThemeToggle`.
+2. Verify the page background is deep dark green (`forest-900`) with no neon-green text anywhere.
+3. Check each component:
+   - Header subtitle: should be pale/muted green (not vivid forest-300)
+   - WordTable rows: word and translation text should be pale (not vivid)
+   - Gender and date labels: visibly muted secondary text (not bright green)
+   - Category badge: pale text on dark background with subtle ring
+   - SearchBar: icon and placeholder in muted tone
+   - AddWordModal (open via "Add New Word"): form labels and cancel button should be pale, not vivid green
+
+**Light mode regression:**
+
+4. Switch to light mode. Verify nothing looks different from the pre-change state — no light-mode class was touched.
+
+**FOWT regression:**
+
+5. Disable JavaScript in browser devtools, then re-enable and hard-reload. The page should render immediately in the correct theme (no flicker).
+
+**Edge cases:**
+
+- System dark mode preference (no `localStorage.theme` set) → page should default to dark mode on first load without flash
+- Rapid toggle (light → dark → light) → no visual glitch or state desync in `ThemeToggle`
+
+---
+
+### Open Questions / Risks
+
+- [x] **`focus:ring-forest-500` not dark-mode scoped:** **Decision: add `dark:focus:ring-forest-400`** to `AddWordModal.tsx` and `SearchBar.tsx`. Follows the same one-step-lighter remapping rule as every other mid-range token; `forest-400` (#74c69d) remains clearly visible for keyboard-focus accessibility. Leaving it unchanged would make the focus ring the one remaining neon-green element in dark mode.
+- [ ] **`dark:text-forest-200` in AddWordModal form labels:** Shifting to `dark:text-forest-100` makes labels nearly white. **Deferred to visual review** — start with `dark:text-forest-100`, revert to `dark:text-forest-200` if the contrast looks excessive during the manual check.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.8] - 2026-05-07
+
+### Changed
+
+- **Frontend**: Muted dark-mode colour palette across all components — shifted mid-range `forest-300`–`forest-500` accent text tokens one step lighter (toward `forest-100`/`forest-200`) to reduce neon-green saturation on dark backgrounds.
+- **Frontend**: Added `dark:focus:ring-forest-400` to all form inputs in `AddWordModal` and `SearchBar` so focus rings match the muted dark-mode palette.
+
 ## [0.2.7] - 2026-05-04
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "backend"
-version = "0.2.7"
+version = "0.2.8"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Simone Porreca", email = "porrecasimone@gmail.com" }]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -44,7 +44,7 @@ A Next.js 16 single-page application that provides the user interface for Vademe
 ## Constraints / invariants
 
 - The backend base URL is hardcoded to `http://localhost:8000` in both `page.tsx` and `lib/api.ts`; no environment-variable abstraction exists yet.
-- Dark mode state is read from `localStorage` only on the client; there is no SSR-safe hydration guard, so a flash-of-wrong-theme is possible on first load.
+- Dark mode is initialised by an inline `<script>` in `layout.tsx` that runs before React hydrates, reading `localStorage.theme` and the system `prefers-color-scheme` preference. The `<html>` element has `suppressHydrationWarning` set.
 - `wordSchema` is the single source of truth for form validation — both modals must use it; diverging from it will silently break backend contract alignment.
 - Without a search query, the word list is capped at 10 results (`?limit=10`); search results are uncapped.
 
@@ -54,3 +54,11 @@ A Next.js 16 single-page application that provides the user interface for Vademe
 - **Inline editing of words** — EditWordModal is read-only; editing is not yet implemented
 - **Pagination** — the table shows all search results without paging
 - **Backend persistence logic** — handled entirely by the FastAPI backend and PostgreSQL
+
+## Changelog
+
+### 2026-05-07
+
+- Muted dark-mode colour palette across `page.tsx`, `WordTable.tsx`, `ThemeToggle.tsx`, `AddWordModal.tsx`, and `SearchBar.tsx`: shifted mid-range `forest-300`–`forest-500` accent text tokens one step lighter to reduce neon-green saturation on dark backgrounds.
+- Added `dark:focus:ring-forest-400` to all form inputs in `AddWordModal` and the search input in `SearchBar`.
+- Corrected stale README constraint: dark-mode flash-of-wrong-theme fix is already implemented in `layout.tsx`.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -47,7 +47,7 @@ export default function Home() {
             <h1 className="text-4xl font-bold text-forest-900 dark:text-forest-50">
               Vademecum Germanicum
             </h1>
-            <p className="text-forest-700 dark:text-forest-300 mt-2">
+            <p className="text-forest-700 dark:text-forest-200 mt-2">
               Your personal German vocabulary vault.
             </p>
           </div>
@@ -69,11 +69,11 @@ export default function Home() {
         {/* Content Section */}
         <div className="bg-white dark:bg-forest-800 rounded-xl shadow-sm border border-forest-200 dark:border-forest-700 p-6">
           {loading ? (
-            <p className="text-center py-10 text-forest-600 dark:text-forest-400">
+            <p className="text-center py-10 text-forest-600 dark:text-forest-300">
               Loading your vocabulary...
             </p>
           ) : words.length === 0 ? (
-            <p className="text-center py-10 text-forest-600 dark:text-forest-400 italic">
+            <p className="text-center py-10 text-forest-600 dark:text-forest-300 italic">
               No words found. Time to add your first one!
             </p>
           ) : (

--- a/frontend/src/components/AddWordModal.tsx
+++ b/frontend/src/components/AddWordModal.tsx
@@ -98,13 +98,13 @@ export default function AddWordModal({ onWordAdded }: AddWordModalProps) {
             </h2>
             <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
               <div>
-                <label className="text-forest-700 dark:text-forest-200 block text-sm font-medium">
+                <label className="text-forest-700 dark:text-forest-100 block text-sm font-medium">
                   German Word
                 </label>
                 <div className="flex gap-2 mt-1">
                   <input
                     {...register("word")}
-                    className="text-forest-800 dark:text-forest-100 dark:bg-forest-900 border border-forest-300 dark:border-forest-600 w-full p-2 rounded focus:outline-none focus:ring-2 focus:ring-forest-500"
+                    className="text-forest-800 dark:text-forest-100 dark:bg-forest-900 border border-forest-300 dark:border-forest-600 w-full p-2 rounded focus:outline-none focus:ring-2 focus:ring-forest-500 dark:focus:ring-forest-400"
                   />
                   <button
                     type="button"
@@ -127,12 +127,12 @@ export default function AddWordModal({ onWordAdded }: AddWordModalProps) {
               </div>
 
               <div>
-                <label className="text-forest-700 dark:text-forest-200 block text-sm font-medium">
+                <label className="text-forest-700 dark:text-forest-100 block text-sm font-medium">
                   Translation
                 </label>
                 <input
                   {...register("translation")}
-                  className="text-forest-800 dark:text-forest-100 dark:bg-forest-900 border border-forest-300 dark:border-forest-600 w-full p-2 rounded focus:outline-none focus:ring-2 focus:ring-forest-500"
+                  className="text-forest-800 dark:text-forest-100 dark:bg-forest-900 border border-forest-300 dark:border-forest-600 w-full p-2 rounded focus:outline-none focus:ring-2 focus:ring-forest-500 dark:focus:ring-forest-400"
                 />
                 {errors.translation && (
                   <p className="text-red-500 text-xs">
@@ -143,12 +143,12 @@ export default function AddWordModal({ onWordAdded }: AddWordModalProps) {
 
               <div className="flex gap-4">
                 <div className="flex-1">
-                  <label className="text-forest-700 dark:text-forest-200 block text-sm font-medium">
+                  <label className="text-forest-700 dark:text-forest-100 block text-sm font-medium">
                     Gender
                   </label>
                   <select
                     {...register("gender")}
-                    className="text-forest-800 dark:text-forest-100 dark:bg-forest-900 border border-forest-300 dark:border-forest-600 w-full p-2 rounded focus:outline-none focus:ring-2 focus:ring-forest-500"
+                    className="text-forest-800 dark:text-forest-100 dark:bg-forest-900 border border-forest-300 dark:border-forest-600 w-full p-2 rounded focus:outline-none focus:ring-2 focus:ring-forest-500 dark:focus:ring-forest-400"
                   >
                     <option value="none">none</option>
                     <option value="der">der</option>
@@ -157,12 +157,12 @@ export default function AddWordModal({ onWordAdded }: AddWordModalProps) {
                   </select>
                 </div>
                 <div className="flex-1">
-                  <label className="text-forest-700 dark:text-forest-200 block text-sm font-medium">
+                  <label className="text-forest-700 dark:text-forest-100 block text-sm font-medium">
                     Category
                   </label>
                   <select
                     {...register("category")}
-                    className="text-forest-800 dark:text-forest-100 dark:bg-forest-900 border border-forest-300 dark:border-forest-600 w-full p-2 rounded focus:outline-none focus:ring-2 focus:ring-forest-500"
+                    className="text-forest-800 dark:text-forest-100 dark:bg-forest-900 border border-forest-300 dark:border-forest-600 w-full p-2 rounded focus:outline-none focus:ring-2 focus:ring-forest-500 dark:focus:ring-forest-400"
                   >
                     <option value="noun">noun</option>
                     <option value="verb">verb</option>
@@ -174,17 +174,17 @@ export default function AddWordModal({ onWordAdded }: AddWordModalProps) {
               </div>
 
               <div>
-                <label className="text-forest-700 dark:text-forest-200 block text-sm font-medium">
+                <label className="text-forest-700 dark:text-forest-100 block text-sm font-medium">
                   Plural
                 </label>
                 <input
                   {...register("word_plural")}
-                  className="text-forest-800 dark:text-forest-100 dark:bg-forest-900 border border-forest-300 dark:border-forest-600 w-full p-2 rounded focus:outline-none focus:ring-2 focus:ring-forest-500"
+                  className="text-forest-800 dark:text-forest-100 dark:bg-forest-900 border border-forest-300 dark:border-forest-600 w-full p-2 rounded focus:outline-none focus:ring-2 focus:ring-forest-500 dark:focus:ring-forest-400"
                 />
               </div>
 
               <div>
-                <label className="text-forest-700 dark:text-forest-200 block text-sm font-medium">
+                <label className="text-forest-700 dark:text-forest-100 block text-sm font-medium">
                   Example Sentences
                 </label>
                 <textarea
@@ -198,7 +198,7 @@ export default function AddWordModal({ onWordAdded }: AddWordModalProps) {
                 <button
                   type="button"
                   onClick={() => setIsOpen(false)}
-                  className="text-forest-600 dark:text-forest-300 hover:text-forest-800 dark:hover:text-forest-100 transition-colors"
+                  className="text-forest-600 dark:text-forest-200 hover:text-forest-800 dark:hover:text-forest-100 transition-colors"
                 >
                   Cancel
                 </button>

--- a/frontend/src/components/SearchBar.tsx
+++ b/frontend/src/components/SearchBar.tsx
@@ -28,11 +28,11 @@ export default function SearchBar({
   return (
     <div className="relative group">
       <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-        <Search className="h-5 w-5 text-forest-400 dark:text-forest-500 group-focus-within:text-forest-600 dark:group-focus-within:text-forest-400 transition-colors" />
+        <Search className="h-5 w-5 text-forest-400 dark:text-forest-400 group-focus-within:text-forest-600 dark:group-focus-within:text-forest-300 transition-colors" />
       </div>
       <input
         type="text"
-        className="block w-full pl-10 pr-10 py-2.5 border border-forest-200 dark:border-forest-700 rounded-lg bg-white dark:bg-forest-900 placeholder-forest-400 dark:placeholder-forest-500 text-forest-900 dark:text-forest-100 focus:outline-none focus:ring-2 focus:ring-forest-500 focus:border-transparent transition-all shadow-sm"
+        className="block w-full pl-10 pr-10 py-2.5 border border-forest-200 dark:border-forest-700 rounded-lg bg-white dark:bg-forest-900 placeholder-forest-400 dark:placeholder-forest-400 text-forest-900 dark:text-forest-100 focus:outline-none focus:ring-2 focus:ring-forest-500 dark:focus:ring-forest-400 focus:border-transparent transition-all shadow-sm"
         placeholder={placeholder}
         value={inputValue}
         onChange={(e) => setInputValue(e.target.value)}
@@ -40,7 +40,7 @@ export default function SearchBar({
       {inputValue && (
         <button
           onClick={() => setInputValue("")}
-          className="absolute inset-y-0 right-0 pr-3 flex items-center text-forest-400 hover:text-forest-600 dark:text-forest-500 dark:hover:text-forest-300"
+          className="absolute inset-y-0 right-0 pr-3 flex items-center text-forest-400 hover:text-forest-600 dark:text-forest-400 dark:hover:text-forest-200"
         >
           <X className="h-4 w-4" />
         </button>

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -27,7 +27,7 @@ export default function ThemeToggle() {
     <button
       onClick={toggle}
       aria-label="Toggle dark mode"
-      className="p-2 rounded-lg text-forest-700 hover:bg-forest-100 dark:text-forest-300 dark:hover:bg-forest-800 transition-colors"
+      className="p-2 rounded-lg text-forest-700 hover:bg-forest-100 dark:text-forest-200 dark:hover:bg-forest-800 transition-colors"
     >
       {isDark ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
     </button>

--- a/frontend/src/components/WordTable.tsx
+++ b/frontend/src/components/WordTable.tsx
@@ -49,24 +49,24 @@ export default function WordTable({ words, onRefresh }: WordTableProps) {
                 className="hover:bg-forest-50 dark:hover:bg-forest-800 cursor-pointer transition-colors"
               >
                 <td className="whitespace-nowrap py-4 pl-4 pr-3 text-sm">
-                  <span className="font-bold text-forest-700 dark:text-forest-300">
+                  <span className="font-bold text-forest-700 dark:text-forest-200">
                     {word.word}
                   </span>
                   {word.gender && word.gender !== "none" && (
-                    <span className="ml-2 text-xs font-medium text-forest-400 dark:text-forest-500 uppercase">
+                    <span className="ml-2 text-xs font-medium text-forest-400 dark:text-forest-400 uppercase">
                       ({word.gender})
                     </span>
                   )}
                 </td>
-                <td className="whitespace-nowrap px-3 py-4 text-sm text-forest-600 dark:text-forest-300">
+                <td className="whitespace-nowrap px-3 py-4 text-sm text-forest-600 dark:text-forest-200">
                   {word.translation}
                 </td>
                 <td className="whitespace-nowrap px-3 py-4 text-sm">
-                  <span className="inline-flex items-center rounded-md bg-forest-50 dark:bg-forest-700 px-2 py-1 text-xs font-medium text-forest-700 dark:text-forest-200 ring-1 ring-inset ring-forest-700/10 dark:ring-forest-400/20">
+                  <span className="inline-flex items-center rounded-md bg-forest-50 dark:bg-forest-700 px-2 py-1 text-xs font-medium text-forest-700 dark:text-forest-100 ring-1 ring-inset ring-forest-700/10 dark:ring-forest-300/20">
                     {word.category || "N/A"}
                   </span>
                 </td>
-                <td className="whitespace-nowrap px-3 py-4 text-sm text-forest-400 dark:text-forest-500">
+                <td className="whitespace-nowrap px-3 py-4 text-sm text-forest-400 dark:text-forest-400">
                   {new Date(word.created_at).toLocaleDateString()}
                 </td>
               </tr>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vademecum-germanicum"
-version = "0.2.7"
+version = "0.2.8"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Description

The PR resolves #29 by refactoring the UI colors. 

## Changelog

### Changed

- **Frontend**: Muted dark-mode colour palette across all components — shifted mid-range `forest-300`–`forest-500` accent text tokens one step lighter (toward `forest-100`/`forest-200`) to reduce neon-green saturation on dark backgrounds.
- **Frontend**: Added `dark:focus:ring-forest-400` to all form inputs in `AddWordModal` and `SearchBar` so focus rings match the muted dark-mode palette.

## Checklist

### Mandatory

- [x] The title of the Pull Request starts with the JIRA ticket number (if provided)
- [x] The title of the Pull Request must reflect the corresponding issue title
- [x] It has to have a `Description` section, specifying which is the `#issue` it's resolving and how
- [x] It has to have a `Changelog` section, reporting what has been changed in the corresponding issue
- [x] The project version must have been updated

### Optional

- [x] Update the Wiki
- [x] Update the `README.md`
- [x] Update the `CHANGELOG.md`
