### PR TITLE
Feat/35 Data model api

### DIFF
--- a/.claude/planning/3-better-fields-structure/35-data-model-api.md
+++ b/.claude/planning/3-better-fields-structure/35-data-model-api.md
@@ -1,0 +1,355 @@
+# #35: Data Model & API
+
+**GitHub Issue:** [#35 — Data Model & API](https://github.com/Volscente/vademecum-germanicum/issues/35)
+**GitHub Milestone:** [3-better-fields-structure](https://github.com/Volscente/vademecum-germanicum/milestones)
+**Notion page:** [3 — Better Fields Structure](https://www.notion.so/3-Better-Fields-Structure-3575cc6c0f07801a84ced321560685cc)
+
+---
+
+## Technical Scope
+
+**In scope:**
+
+- `backend/src/backend/models.py` — add `CaseEnum`, `RegisterEnum`; add ORM models `Sense`, `GrammarPattern`, `ExampleSentence`; extend `Word` with `auxiliary_verb`, `principal_forms` (JSON), and `senses` relationship; remove columns `prepositions`, `example_sentences`, `idiomatic_usages`; retain `translation`
+- `backend/src/backend/schemas.py` — add `GrammarPatternCreate/Read`, `ExampleSentenceCreate/Read`, `SenseCreate/Read`; extend `WordCreate`/`WordRead`/`WordUpdate` to embed `senses`; retain `translation` field; import new enums
+- `backend/src/backend/main.py` — update `POST /words/` (nested sense persistence in single transaction); update `GET /words/` (eager-load via `selectinload`); update `PUT /words/{id}` (replace sense list atomically); search filter unchanged (`word` and `translation` columns both retained)
+- `migration.sql` — SQL script to alter the live `words` table: drop `prepositions`, `example_sentences`, `idiomatic_usages` columns; add `auxiliary_verb` and `principal_forms`; new sense-family tables are auto-created by `models.Base.metadata.create_all` on startup
+- `backend/tests/test_words.py` — update existing tests for new `WordRead` shape; add tests for nested persistence and constraint enforcement
+- `backend/tests/fixtures/word_payloads.py` — update `valid_word_payload` to include a `senses` array
+
+**Out of scope:**
+
+- LLM enrichment (`enrichment.py`) — TASK-2 (#36)
+- Frontend TypeScript interfaces, Zod schema, and React components — TASK-3 (#37)
+- Alembic or any automated migration toolchain
+
+---
+
+## Architecture
+
+```txt
+POST /words/
+     │  body: WordCreate { word, gender, auxiliary_verb, principal_forms,
+     │                     senses: [{ meaning_summary, register,
+     │                                grammar_patterns: [{preposition, case}],
+     │                                example_sentences: [{german, english}] }] }
+     │
+     │  Pydantic: senses min_length=1, grammar_patterns min_length=1,
+     │            example_sentences min_length=1  → HTTP 422 if violated
+     ▼
+  Word() ORM
+     │
+     └── Sense()  (one per senses entry, cascade insert)
+           ├── GrammarPattern()  (one per grammar_patterns entry)
+           └── ExampleSentence() (one per example_sentences entry)
+     │
+     db.add(word) → db.commit()  (single transaction)
+     │
+     ▼
+  WordRead { id, word, ..., senses: [SenseRead { grammar_patterns, example_sentences }] }
+
+
+GET /words/
+     │  query: skip, limit, search
+     ▼
+  db.query(Word)
+     .options(
+         selectinload(Word.senses).selectinload(Sense.grammar_patterns),
+         selectinload(Word.senses).selectinload(Sense.example_sentences),
+     )
+     .filter(or_(Word.word.ilike(f"%{search}%"),
+                 Word.translation.ilike(f"%{search}%")) if search else ...)
+     │
+     ▼
+  list[WordRead]
+
+
+PUT /words/{id}
+     │  body: WordUpdate (all fields optional)
+     ▼
+  fetch Word by id  →  HTTP 404 if missing
+     │
+     ├── patch scalar fields (exclude_unset)
+     │
+     └── if senses present in body:
+           delete existing Sense children (cascade deletes GrammarPattern + ExampleSentence)
+           insert new Sense children
+     │
+     db.commit()
+     │
+     ▼
+  WordRead (with refreshed senses)
+```
+
+### Why replace-all for sense updates
+
+`PUT /words/{id}` replaces the full sense list when `senses` is included in the body, rather than patching individual senses by ID. This avoids partial-update complexity (tracking which sense IDs to keep, delete, or upsert). The client always sends the complete desired state.
+
+---
+
+## Tech Stack
+
+No new packages required. All new models, schemas, and loading strategies use existing dependencies (SQLAlchemy, Pydantic, FastAPI).
+
+---
+
+## Implementation Details
+
+### Modules / Files
+
+| File                                              | Action | Description                                                                              |
+| ------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------- |
+| `backend/src/backend/models.py`                   | Modify | Add `CaseEnum`, `RegisterEnum`, `Sense`, `GrammarPattern`, `ExampleSentence`; extend `Word` |
+| `backend/src/backend/schemas.py`                  | Modify | Add sense-family schemas; extend `WordCreate`, `WordRead`, `WordUpdate`                  |
+| `backend/src/backend/main.py`                     | Modify | Update `POST /words/`, `GET /words/`, `PUT /words/{id}`                                  |
+| `migration.sql`                                   | Create | Alter `words` table: drop deprecated columns, add verb morphology columns                |
+| `backend/tests/test_words.py`                     | Modify | Update tests for new `WordRead` shape; add nested persistence and constraint tests       |
+| `backend/tests/fixtures/word_payloads.py`         | Modify | Update `valid_word_payload` to include a `senses` array                                  |
+
+---
+
+### Key Functions
+
+```python
+@app.post("/words/", response_model=schemas.WordRead)
+def create_word(word: schemas.WordCreate, db: Session = Depends(get_db)) -> models.Word:
+    """Persist a new word with its full sense graph in a single transaction.
+
+    Builds a `Word` ORM instance from the validated `WordCreate` body, then
+    constructs nested `Sense`, `GrammarPattern`, and `ExampleSentence` instances
+    and appends them to `word.senses`. The cascade relationship handles child
+    inserts automatically when `db.add(db_word)` is called.
+
+    Args:
+        word: Validated request body; Pydantic enforces `min_length=1` on
+              `senses`, `grammar_patterns`, and `example_sentences`.
+        db: SQLAlchemy session injected by FastAPI.
+
+    Returns:
+        The persisted `Word` ORM instance, serialized as `WordRead` by FastAPI.
+
+    Raises:
+        HTTPException (422): Raised automatically by FastAPI/Pydantic if
+                             validation constraints are violated (e.g., empty senses list).
+    """
+```
+
+```python
+@app.get("/words/", response_model=list[schemas.WordRead])
+def read_words(
+    skip: int = 0,
+    limit: int = 100,
+    search: str | None = None,
+    db: Session = Depends(get_db),
+) -> list[models.Word]:
+    """List words with their full sense graph, avoiding N+1 queries.
+
+    Uses `selectinload` to eager-load `senses → grammar_patterns` and
+    `senses → example_sentences` in two additional SELECT statements rather
+    than one query per word row. The search filter applies case-insensitive
+    ILIKE on `word` only (the `translation` column is removed in this milestone).
+
+    Args:
+        skip: Number of rows to offset.
+        limit: Maximum number of rows to return.
+        search: If provided, filters by case-insensitive match on the `word` column.
+        db: SQLAlchemy session injected by FastAPI.
+
+    Returns:
+        List of `Word` ORM instances with sense children pre-loaded.
+    """
+```
+
+```python
+@app.put("/words/{word_id}", response_model=schemas.WordRead)
+def update_word(
+    word_id: int,
+    word_update: schemas.WordUpdate,
+    db: Session = Depends(get_db),
+) -> models.Word:
+    """Partially update a word's scalar fields and optionally replace its sense list.
+
+    Scalar fields are patched using `exclude_unset`. If `senses` is present in
+    the request body, the existing `Sense` children are deleted via cascade and
+    replaced with the new list in the same transaction. If `senses` is absent,
+    existing senses are untouched.
+
+    Args:
+        word_id: Primary key of the word to update.
+        word_update: Partial update payload; all fields are optional.
+        db: SQLAlchemy session injected by FastAPI.
+
+    Returns:
+        The updated `Word` ORM instance, serialized as `WordRead`.
+
+    Raises:
+        HTTPException (404): If no word with `word_id` exists in the database.
+        HTTPException (400): If `word`, when provided, is an empty or whitespace-only string.
+    """
+```
+
+---
+
+### Data Models / Schemas
+
+**New enums and ORM models (`backend/src/backend/models.py`):**
+
+```python
+class CaseEnum(str, enum.Enum):
+    nominativ = "Nominativ"
+    akkusativ = "Akkusativ"
+    dativ = "Dativ"
+    genitiv = "Genitiv"
+
+
+class RegisterEnum(str, enum.Enum):
+    formal = "Formal"
+    colloquial = "Colloquial"
+    neutral = "Neutral"
+    technical = "Technical"
+
+
+class ExampleSentence(Base):
+    __tablename__ = "example_sentences"
+    id = Column(Integer, primary_key=True, index=True)
+    sense_id = Column(Integer, ForeignKey("senses.id"), nullable=False)
+    german = Column(String, nullable=False)
+    english = Column(String, nullable=False)
+    sense = relationship("Sense", back_populates="example_sentences")
+
+
+class GrammarPattern(Base):
+    __tablename__ = "grammar_patterns"
+    id = Column(Integer, primary_key=True, index=True)
+    sense_id = Column(Integer, ForeignKey("senses.id"), nullable=False)
+    preposition = Column(String, nullable=True)  # NULL = no preposition required
+    case = Column(Enum(CaseEnum), nullable=False)
+    sense = relationship("Sense", back_populates="grammar_patterns")
+
+
+class Sense(Base):
+    __tablename__ = "senses"
+    id = Column(Integer, primary_key=True, index=True)
+    word_id = Column(Integer, ForeignKey("words.id"), nullable=False)
+    meaning_summary = Column(String, nullable=False)
+    register = Column(Enum(RegisterEnum), nullable=False)
+    word = relationship("Word", back_populates="senses")
+    grammar_patterns = relationship(
+        "GrammarPattern", back_populates="sense", cascade="all, delete-orphan"
+    )
+    example_sentences = relationship(
+        "ExampleSentence", back_populates="sense", cascade="all, delete-orphan"
+    )
+
+
+# Changes to existing Word class:
+#   ADD: auxiliary_verb = Column(String, nullable=True)
+#   ADD: principal_forms = Column(JSON, nullable=True)  # list[str] len=3: [infinitiv, präteritum, partizip_ii]
+#   ADD: senses = relationship("Sense", back_populates="word", cascade="all, delete-orphan")
+#   REMOVE columns: translation, prepositions, example_sentences, idiomatic_usages
+```
+
+**New Pydantic schemas (`backend/src/backend/schemas.py`):**
+
+```python
+class GrammarPatternCreate(BaseModel):
+    preposition: Optional[str] = None
+    case: CaseEnum
+
+
+class GrammarPatternRead(GrammarPatternCreate):
+    id: int
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ExampleSentenceCreate(BaseModel):
+    german: str
+    english: str
+
+
+class ExampleSentenceRead(ExampleSentenceCreate):
+    id: int
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SenseCreate(BaseModel):
+    meaning_summary: str
+    register: RegisterEnum
+    grammar_patterns: list[GrammarPatternCreate] = Field(min_length=1)
+    example_sentences: list[ExampleSentenceCreate] = Field(min_length=1)
+
+
+class SenseRead(BaseModel):
+    id: int
+    meaning_summary: str
+    register: RegisterEnum
+    grammar_patterns: list[GrammarPatternRead]
+    example_sentences: list[ExampleSentenceRead]
+    model_config = ConfigDict(from_attributes=True)
+
+
+# WordBase changes:
+#   REMOVE fields: prepositions, example_sentences, idiomatic_usages
+#   RETAIN field: translation (quick-look summary, used in search)
+#   ADD fields:
+#     auxiliary_verb: Optional[str] = None
+#     principal_forms: Optional[list[str]] = None  # unconstrained JSON; [infinitiv, präteritum, partizip_ii] by convention
+#
+# WordCreate: add senses: list[SenseCreate] = Field(min_length=1)
+# WordRead:   add senses: list[SenseRead]
+# WordUpdate: add senses: Optional[list[SenseCreate]] = None  (absent = leave senses untouched)
+```
+
+---
+
+### Testing Strategy
+
+**Fixture update** (`backend/tests/fixtures/word_payloads.py`):
+
+Update `valid_word_payload` to include a minimal valid `senses` list:
+
+```python
+{
+    "word": "Zuschlag",
+    "gender": "der",
+    "word_nominative": "Zuschlag",
+    "translation": "Surcharge",
+    "category": "noun",
+    "senses": [
+        {
+            "meaning_summary": "Surcharge",
+            "register": "Neutral",
+            "grammar_patterns": [{"preposition": None, "case": "Nominativ"}],
+            "example_sentences": [{"german": "Der Zuschlag beträgt 10 Euro.", "english": "The surcharge is 10 euros."}],
+        }
+    ],
+}
+```
+
+**Updated tests** (`backend/tests/test_words.py`):
+
+- `test_create_word_success` — assert `response.json()["senses"]` has length 1; assert `senses[0]["meaning_summary"] == "Surcharge"`
+- `test_get_words_list` — assert each word in response contains a `senses` key
+- `test_search_words_success` — unchanged in intent; search by `word` and by `translation` both still work
+- `test_update_word_success` — send `senses` in the update payload; assert the new sense list is returned
+
+**New tests** (`backend/tests/test_words.py`):
+
+- `test_create_word_with_multiple_senses` — create a word with 2 senses; assert `GET /words/` returns both senses with their grammar patterns and example sentences
+- `test_create_word_empty_senses_rejected` — POST with `senses=[]`; assert HTTP 422
+- `test_create_word_empty_grammar_patterns_rejected` — POST with a sense containing `grammar_patterns=[]`; assert HTTP 422
+- `test_create_word_empty_example_sentences_rejected` — POST with a sense containing `example_sentences=[]`; assert HTTP 422
+- `test_update_word_replaces_senses` — create a word with 1 sense; PUT with 2 senses; assert response contains exactly 2 senses and original sense is gone
+- `test_update_word_without_senses_preserves_existing` — create a word with 1 sense; PUT with scalar field only (no `senses` key); assert sense count is still 1
+
+**Edge cases:**
+
+- `grammar_patterns` with `preposition=null` → accepted (explicit "no preposition required")
+- `principal_forms` with fewer or more than 3 strings → HTTP 422 (enforced by `min_length=3, max_length=3`)
+- `senses` key absent from `PUT` body → existing senses preserved unchanged
+
+---
+
+### Open Questions / Risks
+
+- [ ] **Models declaration order:** SQLAlchemy requires that referenced models are declared before models that hold `ForeignKey` to them. Declare `ExampleSentence` and `GrammarPattern` before `Sense`, and `Sense` before the `Word` relationship is fully wired. **Target:** during implementation of `models.py`

--- a/.claude/planning/3-better-fields-structure/planning.md
+++ b/.claude/planning/3-better-fields-structure/planning.md
@@ -40,7 +40,7 @@ All backend tests pass with the new `WordRead` shape; `GET /words/` returns a `s
 - `backend/src/backend/models.py` — new `Sense`, `GrammarPattern`, `ExampleSentence` ORM models; `Word` gains `auxiliary_verb`, `principal_forms` (JSON), and `senses` relationship; `CaseEnum` and `RegisterEnum` added
 - `backend/src/backend/schemas.py` — `SenseCreate`/`SenseRead`, `GrammarPatternCreate`/`GrammarPatternRead`, `ExampleSentenceCreate`/`ExampleSentenceRead`; `WordCreate`/`WordRead` embed `senses: list[...]`
 - `backend/src/backend/main.py` — updated `POST /words/`, `PUT /words/{id}` (transactional nested persistence), `GET /words/` (eager-load via `selectinload`)
-- `migration.sql` — manual SQL migration script (drops `translation` column, creates new tables)
+- `migration.sql` — manual SQL migration script (drops `prepositions`, `example_sentences`, `idiomatic_usages` columns; adds `auxiliary_verb` and `principal_forms` to `words`; creates new `senses`, `grammar_patterns`, `example_sentences` tables; `translation` column is retained)
 - `backend/tests/` — updated and new tests covering the new `WordRead` shape
 
 ### Technical Overview

--- a/.claude/rfc/3-better-fields-structure/proposal.md
+++ b/.claude/rfc/3-better-fields-structure/proposal.md
@@ -53,7 +53,7 @@ Transition the data architecture from a "Flat Word Model" to a "Sense-Based Mode
 
 ## Integration context
 
-- **API Extension:** The existing word retrieval endpoint must be updated to return an array of "Sense" objects instead of a single string-based translation.
+- **API Extension:** The existing word retrieval endpoint must be updated to return an array of "Sense" objects in addition to the existing `translation` field, which is retained as a quick-look summary for table display and search.
 - **Frontend Refactor:** The "Word Detail" view in the mobile app must be redesigned to accommodate the hierarchical structure of Senses, Prepositions, and Examples.
 - **Data Model:** The current Word data model must be update with the new Word Structure
 - **Word Enrichment:** The existing word enrichment endpoint must be updated to return the new Word Structure

--- a/.claude/rfc/3-better-fields-structure/rfc.md
+++ b/.claude/rfc/3-better-fields-structure/rfc.md
@@ -172,7 +172,7 @@ A: Pydantic validation fires before any database write, returns a structured HTT
 
 **Q: What happens to existing word entries after the migration?**
 
-A: The manual migration script drops the `translation` column and creates the new `sense`, `grammar_pattern`, and `example_sentence` tables. Existing word rows will have no senses — they appear in the UI with an empty sense list and a prompt to re-enrich or edit. No data from the old `translation` column is migrated automatically; users must re-enrich or manually add senses to existing words.
+A: The migration script adds `auxiliary_verb` and `principal_forms` columns to `words`, drops the now-redundant text-blob columns (`prepositions`, `example_sentences`, `idiomatic_usages`), and creates the new `senses`, `grammar_patterns`, and `example_sentences` tables. The `translation` column is **retained** — it serves as a quick-look summary for table display and search. Existing words keep their current `translation` value and appear in the UI with an empty sense list and a prompt to re-enrich or manually add senses.
 
 **Q: How does `GET /words/` change for the table view — won't eager-loading the full sense graph be heavy?**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-05-09
+
+### Added
+
+- **Backend**: New ORM models `Sense`, `GrammarPattern`, `ExampleSentence` in `models.py`, forming a Word → Sense → GrammarPattern / ExampleSentence hierarchy.
+- **Backend**: New enumerations `CaseEnum` (`Nominativ`, `Akkusativ`, `Dativ`, `Genitiv`) and `RegisterEnum` (`Formal`, `Colloquial`, `Neutral`, `Technical`) in `models.py`.
+- **Backend**: New Pydantic schemas `SenseCreate`, `SenseRead`, `GrammarPatternCreate`, `GrammarPatternRead`, `ExampleSentenceCreate`, `ExampleSentenceRead` in `schemas.py`.
+- **Backend**: `auxiliary_verb` and `principal_forms` (JSON) fields on the `Word` model and `WordBase` schema for verb morphology.
+- **Backend**: `migration.sql` — manual SQL script to migrate the live `words` table (drops deprecated columns, adds verb morphology columns).
+- **Tests**: New test suite in `test_words.py` covering multi-sense persistence, empty-list constraint enforcement (`senses`, `grammar_patterns`, `example_sentences`), sense replace on PUT, and sense preservation when `senses` is absent from PUT.
+
+### Changed
+
+- **Backend**: `POST /words/` now accepts and persists a nested sense graph (`senses: list[SenseCreate]`) in a single transaction.
+- **Backend**: `GET /words/` uses `selectinload` to eager-load the full sense graph and avoid N+1 queries.
+- **Backend**: `PUT /words/{id}` atomically replaces the sense list when `senses` is included in the request body; omitting `senses` leaves existing senses unchanged.
+- **Backend**: `WordCreate`, `WordRead`, `WordUpdate` schemas extended with sense-family fields; deprecated flat-text fields (`prepositions`, `example_sentences`, `idiomatic_usages`) removed.
+- **Tests**: `valid_word_payload` fixture updated to include a `senses` array; existing word tests updated for the new `WordRead` shape.
+
 ## [0.2.9] - 2026-05-07
 
 ### Changed

--- a/backend/README.md
+++ b/backend/README.md
@@ -7,8 +7,8 @@ A FastAPI application that serves as the data and AI layer for Vademecum Germani
 ## Key components
 
 - **`src/backend/main.py`** — FastAPI app entry point; defines all routes, CORS middleware, and creates DB tables on startup
-- **`src/backend/models.py`** — SQLAlchemy ORM model (`Word` table) plus `GenderEnum` and `CategoryEnum` enumerations
-- **`src/backend/schemas.py`** — Pydantic schemas for request/response validation: `WordCreate`, `WordRead`, `WordUpdate`, `WordEnrichRequest`
+- **`src/backend/models.py`** — SQLAlchemy ORM models: `Word`, `Sense`, `GrammarPattern`, `ExampleSentence`; plus enumerations `GenderEnum`, `CategoryEnum`, `CaseEnum`, `RegisterEnum`
+- **`src/backend/schemas.py`** — Pydantic schemas for request/response validation: `WordCreate`, `WordRead`, `WordUpdate`, `SenseCreate`, `SenseRead`, `GrammarPatternCreate/Read`, `ExampleSentenceCreate/Read`, `WordEnrichRequest`
 - **`src/backend/database.py`** — SQLAlchemy engine and session factory; exposes `get_db` FastAPI dependency
 - **`src/backend/enrichment.py`** — LLM enrichment logic; defines `WordEnrichment` output model and `enrich_word` async function using PydanticAI with Google Gemini
 
@@ -18,10 +18,10 @@ A FastAPI application that serves as the data and AI layer for Vademecum Germani
 
 - `GET /` — health check; returns a welcome message
 - `POST /words/enrich` — accepts `{"word": str}`, returns `WordEnrichment` with LLM-populated metadata
-- `POST /words/` — creates a new word; accepts `WordCreate`, returns `WordRead`
-- `GET /words/?skip&limit&search` — lists words with optional case-insensitive search on `word` and `translation` fields
-- `PUT /words/{word_id}` — partially updates a word; accepts `WordUpdate` (all fields optional), returns `WordRead`
-- `DELETE /words/{word_id}` — removes a word; returns HTTP 204
+- `POST /words/` — creates a new word with its full sense graph; accepts `WordCreate` (including `senses: list[SenseCreate]`), returns `WordRead`
+- `GET /words/?skip&limit&search` — lists words with optional case-insensitive search on `word` and `translation`; each word embeds its full sense graph
+- `PUT /words/{word_id}` — partially updates a word; accepts `WordUpdate` (all fields optional, including `senses`); when `senses` is provided it replaces the existing sense list; returns `WordRead`
+- `DELETE /words/{word_id}` — removes a word and all its senses (cascade); returns HTTP 204
 
 **Python-level:**
 
@@ -44,8 +44,10 @@ A FastAPI application that serves as the data and AI layer for Vademecum Germani
 - `GEMINI_API_KEY` must be set for enrichment calls; requests to `POST /words/enrich` will return HTTP 422 if the key is missing or the LLM is unreachable.
 - CORS is locked to `http://localhost:3000`; any other origin is rejected.
 - `PUT /words/{word_id}` enforces that `word` and `translation`, if provided, are non-empty strings — an empty string triggers HTTP 400, not a schema validation error.
+- Every `WordCreate` must include at least one `Sense`; every `Sense` must include at least one `GrammarPattern` and at least one `ExampleSentence` — enforced at the Pydantic layer (HTTP 422 on violation).
+- `GrammarPattern.preposition` is nullable — `null` explicitly means "no preposition required".
 - The enrichment agent is instantiated per-request (no singleton); this is intentional to pick up env var changes without a restart, but adds per-call overhead.
-- DB tables are created at import time via `models.Base.metadata.create_all`; schema migrations are not managed (no Alembic).
+- DB tables are created at import time via `models.Base.metadata.create_all`; schema migrations are not managed (no Alembic). Breaking schema changes require a manual SQL migration script.
 
 ## Out of scope
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "backend"
-version = "0.2.9"
+version = "0.3.0"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Simone Porreca", email = "porrecasimone@gmail.com" }]

--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -1,7 +1,7 @@
 from fastapi import Depends, FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import or_
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from . import models, schemas
 from .database import engine, get_db
@@ -20,6 +20,36 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+def _load_word_with_senses(db: Session, word_id: int) -> models.Word | None:
+    """Fetch a single Word with its full sense graph eager-loaded."""
+    return (
+        db.query(models.Word)
+        .options(
+            selectinload(models.Word.senses).selectinload(models.Sense.grammar_patterns),
+            selectinload(models.Word.senses).selectinload(models.Sense.example_sentences),
+        )
+        .filter(models.Word.id == word_id)
+        .first()
+    )
+
+
+def _build_sense_orm(sense_data: schemas.SenseCreate) -> models.Sense:
+    """Construct a Sense ORM instance with its grammar patterns and example sentences."""
+    db_sense = models.Sense(
+        meaning_summary=sense_data.meaning_summary,
+        register=sense_data.register,
+    )
+    for gp in sense_data.grammar_patterns:
+        db_sense.grammar_patterns.append(
+            models.GrammarPattern(preposition=gp.preposition, case=gp.case)
+        )
+    for es in sense_data.example_sentences:
+        db_sense.example_sentences.append(
+            models.ExampleSentence(german=es.german, english=es.english)
+        )
+    return db_sense
 
 
 @app.get("/")
@@ -49,32 +79,63 @@ async def enrich_word_endpoint(
 
 
 @app.post("/words/", response_model=schemas.WordRead)
-def create_word(word: schemas.WordCreate, db: Session = Depends(get_db)):
+def create_word(word: schemas.WordCreate, db: Session = Depends(get_db)) -> models.Word:
+    """Persist a new word with its full sense graph in a single transaction.
+
+    Builds a `Word` ORM instance from the validated `WordCreate` body, then
+    constructs nested `Sense`, `GrammarPattern`, and `ExampleSentence` instances
+    and appends them to `word.senses`. The cascade relationship handles child
+    inserts automatically when `db.add(db_word)` is called.
+
+    Args:
+        word: Validated request body; Pydantic enforces `min_length=1` on
+              `senses`, `grammar_patterns`, and `example_sentences`.
+        db: SQLAlchemy session injected by FastAPI.
+
+    Returns:
+        The persisted `Word` ORM instance, serialized as `WordRead` by FastAPI.
+
+    Raises:
+        HTTPException (422): Raised automatically by FastAPI/Pydantic if
+                             validation constraints are violated (e.g., empty senses list).
     """
-    Create a word in the database and return it.
-    """
-    # Create the SQLAlchemy model instance
-    db_word = models.Word(**word.model_dump())
+    db_word = models.Word(**word.model_dump(exclude={"senses"}))
+    for sense_data in word.senses:
+        db_word.senses.append(_build_sense_orm(sense_data))
 
     db.add(db_word)
     db.commit()
-    db.refresh(db_word)  # Refresh database to get the saved word back for returning it
-    return db_word
+    return _load_word_with_senses(db, db_word.id)
 
 
 @app.get("/words/", response_model=list[schemas.WordRead])
 def read_words(
     skip: int = 0,
     limit: int = 100,
-    search: str | None = None,  # 2. Add optional search parameter
+    search: str | None = None,
     db: Session = Depends(get_db),
-):
-    """
-    Get matching words from the database with optional search filtering.
-    """
-    query = db.query(models.Word)
+) -> list[models.Word]:
+    """List words with their full sense graph, avoiding N+1 queries.
 
-    # Apply case-insensitive filter if search string is provided
+    Uses `selectinload` to eager-load `senses → grammar_patterns` and
+    `senses → example_sentences` in two additional SELECT statements rather
+    than one query per word row. The search filter applies case-insensitive
+    ILIKE on `word` and `translation`.
+
+    Args:
+        skip: Number of rows to offset.
+        limit: Maximum number of rows to return.
+        search: If provided, filters by case-insensitive match on `word` or `translation`.
+        db: SQLAlchemy session injected by FastAPI.
+
+    Returns:
+        List of `Word` ORM instances with sense children pre-loaded.
+    """
+    query = db.query(models.Word).options(
+        selectinload(models.Word.senses).selectinload(models.Sense.grammar_patterns),
+        selectinload(models.Word.senses).selectinload(models.Sense.example_sentences),
+    )
+
     if search:
         search_filter = f"%{search}%"
         query = query.filter(
@@ -84,18 +145,32 @@ def read_words(
             )
         )
 
-    words = query.offset(skip).limit(limit).all()
-    return words
+    return query.offset(skip).limit(limit).all()
 
 
 @app.put("/words/{word_id}", response_model=schemas.WordRead)
 def update_word(
     word_id: int, word_update: schemas.WordUpdate, db: Session = Depends(get_db)
-):
+) -> models.Word:
+    """Partially update a word's scalar fields and optionally replace its sense list.
+
+    Scalar fields are patched using `exclude_unset`. If `senses` is present in
+    the request body, the existing `Sense` children are deleted via cascade and
+    replaced with the new list in the same transaction. If `senses` is absent,
+    existing senses are untouched.
+
+    Args:
+        word_id: Primary key of the word to update.
+        word_update: Partial update payload; all fields are optional.
+        db: SQLAlchemy session injected by FastAPI.
+
+    Returns:
+        The updated `Word` ORM instance, serialized as `WordRead`.
+
+    Raises:
+        HTTPException (404): If no word with `word_id` exists in the database.
+        HTTPException (400): If `word`, when provided, is an empty or whitespace-only string.
     """
-    Update an existing word in the database.
-    """
-    # Retrieve word from db to be updated
     db_word = db.query(models.Word).filter(models.Word.id == word_id).first()
 
     if not db_word:
@@ -103,10 +178,10 @@ def update_word(
             status_code=404, detail=f"🚨 Word with ID {word_id} not found!"
         )
 
-    # Instance the ORM object from the Pydantic, excluding the unset fields
     update_data = word_update.model_dump(exclude_unset=True)
+    senses_present = "senses" in update_data
+    update_data.pop("senses", None)
 
-    # Check for required fields
     if "word" in update_data and (
         update_data["word"] is None or update_data["word"].strip() == ""
     ):
@@ -122,13 +197,16 @@ def update_word(
             detail="🚨 The 'translation' field cannot be null or empty.",
         )
 
-    # Update the fields in the word retrieved from db
     for key, value in update_data.items():
         setattr(db_word, key, value)
 
+    if senses_present:
+        db_word.senses.clear()
+        for sense_data in word_update.senses:
+            db_word.senses.append(_build_sense_orm(sense_data))
+
     db.commit()
-    db.refresh(db_word)
-    return db_word
+    return _load_word_with_senses(db, word_id)
 
 
 @app.delete("/words/{word_id}", status_code=204)

--- a/backend/src/backend/models.py
+++ b/backend/src/backend/models.py
@@ -4,8 +4,8 @@ SQLAlchemy ORM models for the database Data Schema.
 
 import enum
 
-from sqlalchemy import Column, DateTime, Enum, Integer, String, Text, func
-from sqlalchemy.orm import declarative_base
+from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, JSON, String, func
+from sqlalchemy.orm import declarative_base, relationship
 
 Base = declarative_base()
 
@@ -33,6 +33,81 @@ class CategoryEnum(str, enum.Enum):
     pronoun = "pronoun"
 
 
+class CaseEnum(str, enum.Enum):
+    """
+    German grammatical cases.
+    """
+
+    nominativ = "Nominativ"
+    akkusativ = "Akkusativ"
+    dativ = "Dativ"
+    genitiv = "Genitiv"
+
+
+class RegisterEnum(str, enum.Enum):
+    """
+    Social/stylistic register of a word sense.
+    """
+
+    formal = "Formal"
+    colloquial = "Colloquial"
+    neutral = "Neutral"
+    technical = "Technical"
+
+
+class ExampleSentence(Base):
+    """
+    A German example sentence with its English translation, belonging to a Sense.
+    """
+
+    __tablename__ = "example_sentences"
+
+    id = Column(Integer, primary_key=True, index=True)
+    sense_id = Column(Integer, ForeignKey("senses.id"), nullable=False)
+    german = Column(String, nullable=False)
+    english = Column(String, nullable=False)
+
+    sense = relationship("Sense", back_populates="example_sentences")
+
+
+class GrammarPattern(Base):
+    """
+    A (preposition, grammatical case) pair governing a Sense.
+    preposition is nullable — NULL means no preposition is required.
+    """
+
+    __tablename__ = "grammar_patterns"
+
+    id = Column(Integer, primary_key=True, index=True)
+    sense_id = Column(Integer, ForeignKey("senses.id"), nullable=False)
+    preposition = Column(String, nullable=True)
+    case = Column(Enum(CaseEnum), nullable=False)
+
+    sense = relationship("Sense", back_populates="grammar_patterns")
+
+
+class Sense(Base):
+    """
+    A discrete meaning block within a Word entry.
+    Each Sense has its own register, grammar patterns, and example sentences.
+    """
+
+    __tablename__ = "senses"
+
+    id = Column(Integer, primary_key=True, index=True)
+    word_id = Column(Integer, ForeignKey("words.id"), nullable=False)
+    meaning_summary = Column(String, nullable=False)
+    register = Column(Enum(RegisterEnum), nullable=False)
+
+    word = relationship("Word", back_populates="senses")
+    grammar_patterns = relationship(
+        "GrammarPattern", back_populates="sense", cascade="all, delete-orphan"
+    )
+    example_sentences = relationship(
+        "ExampleSentence", back_populates="sense", cascade="all, delete-orphan"
+    )
+
+
 class Word(Base):
     """
     Words table with every useful information for each word.
@@ -55,14 +130,15 @@ class Word(Base):
     # Plural Case
     word_plural = Column(String, nullable=True)
 
-    # Additional information
+    # Quick-look translation (retained for table display and search)
     translation = Column(String, nullable=False)
     category = Column(Enum(CategoryEnum), nullable=True)
 
-    # Lists
-    prepositions = Column(Text, nullable=True)
-    example_sentences = Column(Text, nullable=True)
-    idiomatic_usages = Column(Text, nullable=True)
+    # Verb morphology
+    auxiliary_verb = Column(String, nullable=True)
+    principal_forms = Column(JSON, nullable=True)  # [infinitiv, präteritum, partizip_ii]
 
     # Metadata
     created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    senses = relationship("Sense", back_populates="word", cascade="all, delete-orphan")

--- a/backend/src/backend/schemas.py
+++ b/backend/src/backend/schemas.py
@@ -7,7 +7,46 @@ from typing import Optional
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from .models import CategoryEnum, GenderEnum
+from .models import CaseEnum, CategoryEnum, GenderEnum, RegisterEnum
+
+
+class GrammarPatternCreate(BaseModel):
+    preposition: Optional[str] = None
+    case: CaseEnum
+
+
+class GrammarPatternRead(GrammarPatternCreate):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class ExampleSentenceCreate(BaseModel):
+    german: str
+    english: str
+
+
+class ExampleSentenceRead(ExampleSentenceCreate):
+    id: int
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SenseCreate(BaseModel):
+    meaning_summary: str
+    register: RegisterEnum
+    grammar_patterns: list[GrammarPatternCreate] = Field(min_length=1)
+    example_sentences: list[ExampleSentenceCreate] = Field(min_length=1)
+
+
+class SenseRead(BaseModel):
+    id: int
+    meaning_summary: str
+    register: RegisterEnum
+    grammar_patterns: list[GrammarPatternRead]
+    example_sentences: list[ExampleSentenceRead]
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 class WordBase(BaseModel):
@@ -22,9 +61,8 @@ class WordBase(BaseModel):
     word_plural: Optional[str] = None
     translation: str
     category: Optional[CategoryEnum] = CategoryEnum.noun
-    prepositions: Optional[str] = None
-    example_sentences: Optional[str] = None
-    idiomatic_usages: Optional[str] = None
+    auxiliary_verb: Optional[str] = None
+    principal_forms: Optional[list[str]] = None
 
 
 class WordCreate(WordBase):
@@ -32,7 +70,7 @@ class WordCreate(WordBase):
     Input model: data used to create a word.
     """
 
-    pass
+    senses: list[SenseCreate] = Field(min_length=1)
 
 
 class WordRead(WordBase):
@@ -42,6 +80,7 @@ class WordRead(WordBase):
 
     id: int
     created_at: datetime
+    senses: list[SenseRead]
 
     # Tells Pydantic to read SQLAlchemy model attributes -> Required when converting DB objects into Pydantic
     model_config = ConfigDict(from_attributes=True)
@@ -60,3 +99,4 @@ class WordUpdate(WordBase):
 
     word: Optional[str] = None
     translation: Optional[str] = None
+    senses: Optional[list[SenseCreate]] = None

--- a/backend/tests/fixtures/word_payloads.py
+++ b/backend/tests/fixtures/word_payloads.py
@@ -16,4 +16,54 @@ def valid_word_payload():
         "word_nominative": "Zuschlag",
         "translation": "Surcharge",
         "category": "noun",
+        "senses": [
+            {
+                "meaning_summary": "Surcharge",
+                "register": "Neutral",
+                "grammar_patterns": [{"preposition": None, "case": "Nominativ"}],
+                "example_sentences": [
+                    {
+                        "german": "Der Zuschlag beträgt 10 Euro.",
+                        "english": "The surcharge is 10 euros.",
+                    }
+                ],
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def two_senses_payload():
+    """
+    Test word object with two senses.
+    """
+    return {
+        "word": "abdrehen",
+        "gender": "none",
+        "translation": "to switch off / to turn away",
+        "category": "verb",
+        "senses": [
+            {
+                "meaning_summary": "To switch off (a device)",
+                "register": "Neutral",
+                "grammar_patterns": [{"preposition": None, "case": "Akkusativ"}],
+                "example_sentences": [
+                    {
+                        "german": "Dreh das Licht ab.",
+                        "english": "Switch off the light.",
+                    }
+                ],
+            },
+            {
+                "meaning_summary": "To turn away (physically)",
+                "register": "Colloquial",
+                "grammar_patterns": [{"preposition": "von", "case": "Dativ"}],
+                "example_sentences": [
+                    {
+                        "german": "Er drehte sich ab.",
+                        "english": "He turned away.",
+                    }
+                ],
+            },
+        ],
     }

--- a/backend/tests/test_words.py
+++ b/backend/tests/test_words.py
@@ -5,20 +5,26 @@ Tests backend word read/creation.
 
 def test_create_word_success(client, valid_word_payload):
     """
-    Ensure the word is created correctly.
+    Ensure the word is created correctly with its sense graph.
     """
     response = client.post("/words/", json=valid_word_payload)
     assert response.status_code == 200
-    assert response.json()["word"] == "Zuschlag"
+    data = response.json()
+    assert data["word"] == "Zuschlag"
+    assert len(data["senses"]) == 1
+    assert data["senses"][0]["meaning_summary"] == "Surcharge"
 
 
 def test_get_words_list(client):
     """
-    Ensure words are retrieved.
+    Ensure words are retrieved and each has a senses key.
     """
     response = client.get("/words/")
     assert response.status_code == 200
-    assert isinstance(response.json(), list)
+    words = response.json()
+    assert isinstance(words, list)
+    for word in words:
+        assert "senses" in word
 
 
 def test_search_words_success(client, valid_word_payload):
@@ -48,19 +54,34 @@ def test_search_words_success(client, valid_word_payload):
 
 def test_update_word_success(client, valid_word_payload):
     """
-    Ensure the word is correctly updated.
+    Ensure the word is correctly updated, including replacing its senses.
     """
     # Create word
     response = client.post("/words/", json=valid_word_payload)
     word_id = response.json()["id"]
 
-    # Update the category
-    update_payload = {"example_sentences": "Der Zuschlag wurde abgeführt"}
+    # Update with a new translation and a new sense
+    update_payload = {
+        "translation": "Fee",
+        "senses": [
+            {
+                "meaning_summary": "Additional fee",
+                "register": "Formal",
+                "grammar_patterns": [{"preposition": None, "case": "Akkusativ"}],
+                "example_sentences": [
+                    {"german": "Die Gebühr ist fällig.", "english": "The fee is due."}
+                ],
+            }
+        ],
+    }
     response = client.put(f"/words/{word_id}", json=update_payload)
 
     assert response.status_code == 200
-    assert response.json()["example_sentences"] == "Der Zuschlag wurde abgeführt"
-    assert response.json()["word"] == "Zuschlag"
+    data = response.json()
+    assert data["word"] == "Zuschlag"
+    assert data["translation"] == "Fee"
+    assert len(data["senses"]) == 1
+    assert data["senses"][0]["meaning_summary"] == "Additional fee"
 
 
 def test_update_word_not_found(client):
@@ -73,9 +94,8 @@ def test_update_word_not_found(client):
 
 def test_delete_word_success(client, valid_word_payload):
     """
-    Esnture the word is correctly deleted.
+    Ensure the word is correctly deleted.
     """
-
     # Create word
     response = client.post("/words/", json=valid_word_payload)
     word_id = response.json()["id"]
@@ -96,3 +116,104 @@ def test_delete_word_not_found(client):
     """
     response = client.delete("/words/9999")
     assert response.status_code == 404
+
+
+def test_create_word_with_multiple_senses(client, two_senses_payload):
+    """
+    Ensure a word created with multiple senses persists all senses with their
+    grammar patterns and example sentences.
+    """
+    response = client.post("/words/", json=two_senses_payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["senses"]) == 2
+
+    # Both senses are returned by GET /words/ with nested data
+    word_id = data["id"]
+    response = client.get("/words/")
+    words = response.json()
+    match = next(w for w in words if w["id"] == word_id)
+    assert len(match["senses"]) == 2
+    assert len(match["senses"][0]["grammar_patterns"]) == 1
+    assert len(match["senses"][0]["example_sentences"]) == 1
+
+
+def test_create_word_empty_senses_rejected(client, valid_word_payload):
+    """
+    Ensure a word with an empty senses list is rejected with HTTP 422.
+    """
+    payload = {**valid_word_payload, "senses": []}
+    response = client.post("/words/", json=payload)
+    assert response.status_code == 422
+
+
+def test_create_word_empty_grammar_patterns_rejected(client, valid_word_payload):
+    """
+    Ensure a sense with an empty grammar_patterns list is rejected with HTTP 422.
+    """
+    payload = {
+        **valid_word_payload,
+        "senses": [
+            {
+                "meaning_summary": "Surcharge",
+                "register": "Neutral",
+                "grammar_patterns": [],
+                "example_sentences": [
+                    {"german": "Der Zuschlag beträgt 10 Euro.", "english": "The surcharge is 10 euros."}
+                ],
+            }
+        ],
+    }
+    response = client.post("/words/", json=payload)
+    assert response.status_code == 422
+
+
+def test_create_word_empty_example_sentences_rejected(client, valid_word_payload):
+    """
+    Ensure a sense with an empty example_sentences list is rejected with HTTP 422.
+    """
+    payload = {
+        **valid_word_payload,
+        "senses": [
+            {
+                "meaning_summary": "Surcharge",
+                "register": "Neutral",
+                "grammar_patterns": [{"preposition": None, "case": "Nominativ"}],
+                "example_sentences": [],
+            }
+        ],
+    }
+    response = client.post("/words/", json=payload)
+    assert response.status_code == 422
+
+
+def test_update_word_replaces_senses(client, valid_word_payload, two_senses_payload):
+    """
+    Ensure that sending senses in PUT replaces the existing sense list entirely.
+    """
+    # Create with 1 sense
+    response = client.post("/words/", json=valid_word_payload)
+    word_id = response.json()["id"]
+    assert len(response.json()["senses"]) == 1
+
+    # Update with 2 senses
+    update_payload = {"senses": two_senses_payload["senses"]}
+    response = client.put(f"/words/{word_id}", json=update_payload)
+    assert response.status_code == 200
+    assert len(response.json()["senses"]) == 2
+
+
+def test_update_word_without_senses_preserves_existing(client, valid_word_payload):
+    """
+    Ensure that omitting senses from PUT leaves existing senses unchanged.
+    """
+    # Create with 1 sense
+    response = client.post("/words/", json=valid_word_payload)
+    word_id = response.json()["id"]
+
+    # Update only a scalar field — no senses key
+    response = client.put(f"/words/{word_id}", json={"translation": "Extra charge"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["translation"] == "Extra charge"
+    assert len(data["senses"]) == 1

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.2.9",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/migration.sql
+++ b/migration.sql
@@ -1,0 +1,17 @@
+-- Migration: 3-better-fields-structure / M1 — Data Model & API
+--
+-- Run this against the live database before deploying the new backend image.
+-- New tables (senses, grammar_patterns, example_sentences) are created
+-- automatically by models.Base.metadata.create_all on startup.
+--
+-- Usage:
+--   docker exec -i vademecum_db psql -U <user> -d <db> < migration.sql
+
+-- Drop deprecated flat-text columns from words table
+ALTER TABLE words DROP COLUMN IF EXISTS prepositions;
+ALTER TABLE words DROP COLUMN IF EXISTS example_sentences;
+ALTER TABLE words DROP COLUMN IF EXISTS idiomatic_usages;
+
+-- Add verb morphology columns
+ALTER TABLE words ADD COLUMN IF NOT EXISTS auxiliary_verb VARCHAR;
+ALTER TABLE words ADD COLUMN IF NOT EXISTS principal_forms JSON;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vademecum-germanicum"
-version = "0.2.9"
+version = "0.3.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Description

The PR resolves the issue #35  by refactoring the Data Model and the APIs with the new Word structure.

## Changelog

### Added

- **Backend**: New ORM models `Sense`, `GrammarPattern`, `ExampleSentence` in `models.py`, forming a Word → Sense → GrammarPattern / ExampleSentence hierarchy.
- **Backend**: New enumerations `CaseEnum` (`Nominativ`, `Akkusativ`, `Dativ`, `Genitiv`) and `RegisterEnum` (`Formal`, `Colloquial`, `Neutral`, `Technical`) in `models.py`.
- **Backend**: New Pydantic schemas `SenseCreate`, `SenseRead`, `GrammarPatternCreate`, `GrammarPatternRead`, `ExampleSentenceCreate`, `ExampleSentenceRead` in `schemas.py`.
- **Backend**: `auxiliary_verb` and `principal_forms` (JSON) fields on the `Word` model and `WordBase` schema for verb morphology.
- **Backend**: `migration.sql` — manual SQL script to migrate the live `words` table (drops deprecated columns, adds verb morphology columns).
- **Tests**: New test suite in `test_words.py` covering multi-sense persistence, empty-list constraint enforcement (`senses`, `grammar_patterns`, `example_sentences`), sense replace on PUT, and sense preservation when `senses` is absent from PUT.

### Changed

- **Backend**: `POST /words/` now accepts and persists a nested sense graph (`senses: list[SenseCreate]`) in a single transaction.
- **Backend**: `GET /words/` uses `selectinload` to eager-load the full sense graph and avoid N+1 queries.
- **Backend**: `PUT /words/{id}` atomically replaces the sense list when `senses` is included in the request body; omitting `senses` leaves existing senses unchanged.
- **Backend**: `WordCreate`, `WordRead`, `WordUpdate` schemas extended with sense-family fields; deprecated flat-text fields (`prepositions`, `example_sentences`, `idiomatic_usages`) removed.
- **Tests**: `valid_word_payload` fixture updated to include a `senses` array; existing word tests updated for the new `WordRead` shape.

## Checklist

### Mandatory

- [x] The title of the Pull Request starts with the JIRA ticket number (if provided)
- [x] The title of the Pull Request must reflect the corresponding issue title
- [x] It has to have a `Description` section, specifying which is the `#issue` it's resolving and how
- [x] It has to have a `Changelog` section, reporting what has been changed in the corresponding issue
- [x] The project version must have been updated

### Optional

- [x] Update the Wiki
- [x] Update the `README.md`
- [x] Update the `CHANGELOG.md`
