### PR TITLE
Feat/37 Frontend refactor

### DIFF
--- a/.claude/planning/3-better-fields-structure/37-frontend-refactor.md
+++ b/.claude/planning/3-better-fields-structure/37-frontend-refactor.md
@@ -1,0 +1,316 @@
+# #37: Frontend Refactor
+
+**GitHub Issue:** [#37 — Frontend Refactor](https://github.com/Volscente/vademecum-germanicum/issues/37)
+**GitHub Milestone:** [3-better-fields-structure](https://github.com/Volscente/vademecum-germanicum/milestones)
+**Notion page:** [3 — Better Fields Structure](https://www.notion.so/3-Better-Fields-Structure-3575cc6c0f07801a84ced321560685cc)
+
+---
+
+## Technical Scope
+
+**In scope:**
+
+- `frontend/src/types/word.ts` — Add `Sense`, `GrammarPattern`, `ExampleSentence` interfaces; update `Word` (add `auxiliary_verb`, `principal_forms`, `senses`) and `WordEnrichment` (add same fields)
+- `frontend/src/lib/wordSchema.ts` — Extend Zod `wordSchema` with nested sense validation (`senseSchema`, `grammarPatternSchema`, `exampleSentenceSchema`)
+- `frontend/src/components/AddWordModal.tsx` — Replace flat fields with a dynamic multi-sense form section; `useFieldArray` manages the sense list; enrichment pre-populates it
+- `frontend/src/components/EditWordModal.tsx` — Full edit form: RHF + `useFieldArray` for senses, `PUT /words/{id}` on submit, "Re-enrich (replaces senses)" button, delete action retained
+- `frontend/src/components/WordTable.tsx` — Change displayed column value from `translation` to `senses[0]?.meaning_summary ?? ''`; add `onWordUpdated` prop
+- `frontend/src/lib/api.ts` — Add `updateWord(wordId, data): Promise<Word>` calling `PUT /words/{id}`
+
+**Out of scope:**
+
+- Backend: M1 (data model) and M2 (LLM enrichment) are already shipped; no backend changes
+- `frontend/src/app/page.tsx` — Root page state and fetch logic are unchanged; `WordTable` handles the `onWordUpdated` callback internally
+- Drag-to-reorder senses within `EditWordModal` or `AddWordModal`
+- Lexical relationships (synonyms, antonyms) and audio generation
+
+---
+
+## Architecture
+
+```txt
+Backend API (port 8000) — already updated (M1 + M2 complete)
+  GET  /words/        → WordRead[]      { senses: SenseRead[]   }
+  POST /words/        ← WordCreate      { senses: SenseCreate[] }
+  POST /words/enrich  → WordEnrichment  { senses: SenseCreate[] }
+           │
+           ▼
+frontend/src/types/word.ts
+  Word · WordEnrichment · Sense · GrammarPattern · ExampleSentence
+           │
+           ├──► frontend/src/lib/wordSchema.ts  (Zod: wordSchema / WordFormValues)
+           │              │
+           │    ┌─────────┴──────────────────────┐
+           │    ▼                                 ▼
+           │  AddWordModal                   EditWordModal
+           │  - useFieldArray(senses)        - Collapsible SenseCard[]
+           │  - "Enrich" fills senses[]      - collapsed: meaning_summary
+           │  - "+ Add Sense" / "Remove"       register badge · pattern chips
+           │  - POST /words/ on submit       - expanded: example_sentences
+           │                                   tap-to-reveal English text
+           │
+           └──► frontend/src/components/WordTable.tsx
+                  senses[0]?.meaning_summary ?? ''  (in place of translation)
+```
+
+### Why `wordSchema` is updated first
+
+`wordSchema` in `wordSchema.ts` is the single source of truth for form validation. Both `AddWordModal` and `EditWordModal` must stay aligned with it. Updating the Zod schema before touching either modal ensures the TypeScript type `WordFormValues` (inferred from the schema) propagates correct shapes to both components without a window of type mismatch.
+
+---
+
+## Tech Stack
+
+No new packages required.
+
+| Existing package    | Usage in this task                                           |
+| ------------------- | ------------------------------------------------------------ |
+| `react-hook-form`   | `useFieldArray` for dynamic sense list in `AddWordModal`     |
+| `zod`               | Extended schema with nested sense/grammar/example validation |
+| `tailwindcss` (v4)  | Existing `forest-*` palette + `transition` for collapsible   |
+| `lucide-react`      | Icons for expand/collapse and tap-to-reveal controls         |
+
+---
+
+## Implementation Details
+
+### Modules / Files
+
+| File                                              | Action | Description                                                                   |
+| ------------------------------------------------- | ------ | ----------------------------------------------------------------------------- |
+| `frontend/src/types/word.ts`                      | Update | Add `Sense`, `GrammarPattern`, `ExampleSentence` interfaces; extend `Word` and `WordEnrichment` |
+| `frontend/src/lib/wordSchema.ts`                  | Update | Add `grammarPatternSchema`, `exampleSentenceSchema`, `senseSchema`; extend `wordSchema` |
+| `frontend/src/components/AddWordModal.tsx`        | Update | Add multi-sense dynamic form section with `useFieldArray`; wire enrichment response to sense array |
+| `frontend/src/components/EditWordModal.tsx`       | Update | Full edit form: RHF + `useFieldArray`, `useEffect` reset on `word` prop change, PUT submit, Re-enrich, delete |
+| `frontend/src/components/WordTable.tsx`           | Update | Display `senses[0]?.meaning_summary ?? ''`; add `onWordUpdated: () => void` prop |
+| `frontend/src/lib/api.ts`                         | Update | Add `updateWord(wordId: number, data: WordFormValues): Promise<Word>`           |
+
+---
+
+### Key Functions
+
+```typescript
+// frontend/src/types/word.ts
+
+interface GrammarPattern {
+  preposition: string | null;  // null = no preposition required
+  case: 'Nominativ' | 'Akkusativ' | 'Dativ' | 'Genitiv';
+}
+
+interface ExampleSentence {
+  german: string;
+  english: string;
+}
+
+interface Sense {
+  meaning_summary: string;
+  register: 'Formal' | 'Colloquial' | 'Neutral' | 'Technical';
+  grammar_patterns: GrammarPattern[];  // min 1
+  example_sentences: ExampleSentence[];  // min 1
+}
+
+interface Word {
+  id: number;
+  word: string;
+  translation: string;
+  gender?: 'Maskulinum' | 'Femininum' | 'Neutrum';
+  category?: string;
+  auxiliary_verb?: 'haben' | 'sein';
+  principal_forms?: [string, string, string];  // Infinitiv, Präteritum, Partizip II
+  senses: Sense[];
+}
+
+interface WordEnrichment {
+  word: string;
+  translation: string;
+  gender?: string;
+  category?: string;
+  auxiliary_verb?: string;
+  principal_forms?: string[];
+  senses: Sense[];
+}
+```
+
+```typescript
+// frontend/src/lib/wordSchema.ts — extended schema
+
+const grammarPatternSchema = z.object({
+  preposition: z.string().nullable(),
+  case: z.enum(['Nominativ', 'Akkusativ', 'Dativ', 'Genitiv']),
+});
+
+const exampleSentenceSchema = z.object({
+  german: z.string().min(1),
+  english: z.string().min(1),
+});
+
+const senseSchema = z.object({
+  meaning_summary: z.string().min(1),
+  register: z.enum(['Formal', 'Colloquial', 'Neutral', 'Technical']),
+  grammar_patterns: z.array(grammarPatternSchema).min(1),
+  example_sentences: z.array(exampleSentenceSchema).min(1),
+});
+
+// wordSchema extended — retain existing top-level fields, add:
+//   auxiliary_verb?: z.enum(['haben', 'sein']).optional()
+//   principal_forms?: z.array(z.string()).length(3).optional()
+//   senses: z.array(senseSchema).min(1)
+```
+
+```typescript
+// frontend/src/components/AddWordModal.tsx — useFieldArray setup
+
+const { fields, append, remove } = useFieldArray({
+  control,
+  name: 'senses',
+});
+
+// On enrich success: call reset({ ...enrichedWord }) to populate the full form
+// including the senses array returned by the backend.
+// "Add Sense" button calls append({ meaning_summary: '', register: 'Neutral',
+//   grammar_patterns: [{ preposition: null, case: 'Akkusativ' }],
+//   example_sentences: [{ german: '', english: '' }] })
+```
+
+```typescript
+// frontend/src/lib/api.ts — new function
+
+export async function updateWord(
+  wordId: number,
+  payload: WordFormValues
+): Promise<Word> {
+  const response = await fetch(`http://localhost:8000/words/${wordId}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    const detail = await response.json().catch(() => ({}));
+    throw new Error(detail?.detail ?? `Update failed: ${response.status}`);
+  }
+  return response.json() as Promise<Word>;
+}
+```
+
+```typescript
+// frontend/src/components/EditWordModal.tsx — key patterns
+
+// 1. Move the isOpen guard AFTER all hook declarations (hooks cannot be conditional)
+
+// 2. Pre-populate form from the word prop
+const { control, register, handleSubmit, reset, watch, formState: { errors } } =
+  useForm<WordFormValues>({
+    resolver: zodResolver(wordSchema),
+    defaultValues: buildDefaultValues(word),
+  });
+
+// Reset whenever the selected word changes (e.g. user closes and opens a different row)
+useEffect(() => { reset(buildDefaultValues(word)); }, [word, reset]);
+
+// 3. Dynamic sense list — same pattern as AddWordModal
+const { fields: senseFields, append, remove } = useFieldArray({ control, name: "senses" });
+
+// grammar_patterns and example_sentences use indexed register() paths (no nested useFieldArray)
+
+// 4. Submit flow
+const onSubmit = async (data: WordFormValues) => {
+  setIsSubmitting(true);
+  setSubmitError(null);
+  try {
+    await updateWord(word.id, data);
+    onWordUpdated();  // triggers fetchWords in page.tsx via WordTable
+    onClose();        // close only on success — keeps modal open on failure
+  } catch (err) {
+    setSubmitError(err instanceof Error ? err.message : "Update failed.");
+  } finally {
+    setIsSubmitting(false);
+  }
+};
+
+// 5. Re-enrich button (replaces entire form including senses)
+const onReEnrich = async () => {
+  const enriched = await enrichWord(watch("word"));
+  reset({ ...enriched });
+};
+
+// 6. Guard: disable "Remove sense" when only one sense remains
+<button type="button" onClick={() => remove(index)} disabled={senseFields.length === 1}>
+  Remove sense
+</button>
+
+// Props addition
+interface EditWordModalProps {
+  word: Word;
+  isOpen: boolean;
+  onClose: () => void;
+  onWordDeleted: () => void;
+  onWordUpdated: () => void;  // new — passed from WordTable as the same onRefresh
+}
+```
+
+---
+
+### Data Models / Schemas
+
+See Key Functions above for the full TypeScript interfaces and Zod schema. The Zod schema is the authoritative runtime contract; the TypeScript interfaces must mirror it exactly.
+
+**Enum alignment with backend:**
+
+| Frontend value  | Backend `CaseEnum`  | Backend `RegisterEnum` |
+| --------------- | ------------------- | ---------------------- |
+| `'Nominativ'`   | `Nominativ`         | —                      |
+| `'Akkusativ'`   | `Akkusativ`         | —                      |
+| `'Dativ'`       | `Dativ`             | —                      |
+| `'Genitiv'`     | `Genitiv`           | —                      |
+| `'Formal'`      | —                   | `Formal`               |
+| `'Colloquial'`  | —                   | `Colloquial`           |
+| `'Neutral'`     | —                   | `Neutral`              |
+| `'Technical'`   | —                   | `Technical`            |
+
+---
+
+### Testing Strategy
+
+No automated frontend tests exist in this project; verification is manual.
+
+**End-to-end flow (golden path):**
+
+```bash
+just dev   # starts backend + frontend
+```
+
+1. Open `http://localhost:3000`
+2. Click "Add Word" → enter a German verb → click "Enrich"
+3. Verify the sense array populates (at least 1 sense with grammar patterns and example sentences)
+4. Manually add a second sense via "+ Add Sense"; fill required fields
+5. Submit → confirm word appears in table with `meaning_summary` of first sense
+6. Click the table row → `EditWordModal` opens pre-filled with all fields including senses
+7. Edit a sense's `meaning_summary` → save → table refreshes with new value
+8. Click the row again → edited data is shown (confirms PUT round-trip)
+9. Click "Re-enrich (replaces senses)" → new senses populate the form; save → persisted
+10. Delete the word → verify it disappears from the table
+
+**Edge cases:**
+
+- Enrichment returns 0 senses → backend returns HTTP 422; frontend should surface the error message without crashing
+- User submits form with 0 senses → Zod validation fires before network call; form shows inline error
+- `senses[0]` is undefined (legacy word with empty senses array) → `WordTable` shows empty string, no crash
+- `principal_forms` is absent (non-verb) → `EditWordModal` omits the verb morphology section entirely
+- Sense card with `preposition: null` → grammar chip renders as "— + Akkusativ" (or similar convention); must not show "null"
+
+**Regression checks:**
+
+- Search still filters the word list after the `translation` column change in `WordTable`
+- Theme toggle (dark/light mode) still works across all updated components
+- Delete from `EditWordModal` still triggers page refresh via `onWordDeleted`
+- AddWordModal submit still works (shared `wordSchema` not broken by changes)
+- ESLint: `cd frontend && npm run lint`
+
+---
+
+### Open Questions / Risks
+
+- [x] **`EditWordModal` verb morphology display:** The RFC says `auxiliary_verb` and `principal_forms` live at the `Word` level and should appear in a dedicated "Verb Morphology" section above the sense cards. Decide: always render the section (empty if absent) or conditionally render only when `auxiliary_verb` is set. **Target:** start of implementation. **Answer:** Render only when `auxiliary_verb` is set.
+- [x] **Grammar chip format for null preposition:** `GrammarPattern.preposition = null` means "no preposition required." Decide on display convention (e.g., "kein Präposition + Akkusativ" vs "— + Akkusativ") before implementing `EditWordModal` sense cards. **Target:** start of implementation. **Answer:** Use the convention "— + Akkusativ".
+- [x] **Sense ordering in `AddWordModal`:** `useFieldArray` preserves insertion order. No drag-to-reorder is planned; confirm this is acceptable for M3. **Target:** start of implementation. **Answer:** It is acceptable.
+- [x] **`EditWordModal` sense editing:** The frontend README documents `EditWordModal` as read-only. M3 keeps it read-only (display + delete only). If editing senses is desired, it must be scoped to a separate issue. **Target:** confirm before implementation. **Answer:** Include full editing in M3. `EditWordModal` becomes a complete edit form with RHF, `useFieldArray` for senses, PUT submit, Re-enrich button, and delete. `api.ts` is added to in-scope files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-05-09
+
+### Added
+
+- **Frontend**: `Sense`, `GrammarPattern`, `ExampleSentence` TypeScript interfaces in `word.ts` mirroring the new backend sense graph.
+- **Frontend**: `grammarPatternSchema`, `exampleSentenceSchema`, `senseSchema` Zod schemas in `wordSchema.ts`; `wordSchema` extended with `auxiliary_verb`, `principal_forms`, and `senses` (min 1).
+- **Frontend**: `updateWord(wordId, data)` API helper in `api.ts` calling `PUT /words/{id}`.
+
+### Changed
+
+- **Frontend**: `AddWordModal` updated to sense-based form — `example_sentences` textarea replaced by `useFieldArray`-driven senses section; `onEnrich` now uses `reset()` with the full enrichment payload; optional verb morphology inputs (`auxiliary_verb`, `principal_forms`) shown when `category === "verb"`.
+- **Frontend**: `EditWordModal` rewritten as a full edit form — RHF + `useFieldArray` for senses, `useEffect` reset on word prop change, PUT submit, Re-enrich button, `onWordUpdated` callback; `isOpen` guard moved after all hook declarations.
+- **Frontend**: `WordTable` "Meaning" column now displays `senses[0]?.meaning_summary ?? ''`; `onWordUpdated` prop added to `EditWordModal` and wired as `onRefresh`.
+- **Frontend**: `Word` and `WordEnrichment` interfaces updated to sense-based structure — `Word` gains `auxiliary_verb`, `principal_forms`, `senses`; `WordEnrichment` drops old flat fields and gains `auxiliary_verb`, `principal_forms`, `senses`.
+
 ## [0.3.1] - 2026-05-09
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "backend"
-version = "0.3.1"
+version = "0.3.2"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Simone Porreca", email = "porrecasimone@gmail.com" }]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -8,27 +8,29 @@ A Next.js 16 single-page application that provides the user interface for Vademe
 
 - **`src/app/page.tsx`** — Root page; owns all state (words list, search term, loading flag), fetches from the backend, and passes handlers down to child components
 - **`src/components/AddWordModal.tsx`** — Modal form for creating a new word entry; includes an "Enrich" button that calls the AI enrichment API to pre-populate fields
-- **`src/components/EditWordModal.tsx`** — Modal showing word details with a delete action; opened by clicking a row in WordTable
+- **`src/components/EditWordModal.tsx`** — Full edit form for updating word data (all fields including nested senses) with a delete action; opened by clicking a row in WordTable
 - **`src/components/WordTable.tsx`** — Displays the vocabulary as a clickable table; clicking a row opens EditWordModal
 - **`src/components/SearchBar.tsx`** — Debounced search input (300 ms default) that fires an `onSearch` callback when the user pauses typing
 - **`src/components/ThemeToggle.tsx`** — Toggles light/dark mode by manipulating the `dark` CSS class on `<html>` and persisting the choice in `localStorage`
-- **`src/lib/api.ts`** — HTTP client; currently exposes `enrichWord` for calling `POST /words/enrich`
-- **`src/lib/wordSchema.ts`** — Zod schema (`wordSchema`) and derived type (`WordFormValues`) used by AddWordModal for form validation
-- **`src/types/word.ts`** — TypeScript interfaces (`Word`, `WordEnrichment`) that mirror the FastAPI backend schemas
+- **`src/lib/api.ts`** — HTTP client; exposes `enrichWord` (`POST /words/enrich`) and `updateWord` (`PUT /words/{id}`)
+- **`src/lib/wordSchema.ts`** — Zod schemas (`grammarPatternSchema`, `exampleSentenceSchema`, `senseSchema`, `wordSchema`) and derived type (`WordFormValues`) used by both modals for form validation
+- **`src/types/word.ts`** — TypeScript interfaces (`Word`, `WordEnrichment`, `Sense`, `GrammarPattern`, `ExampleSentence`) that mirror the FastAPI backend schemas
 - **`src/app/globals.css`** — Tailwind v4 theme configuration defining the custom `forest-*` green palette and class-based dark mode
 
 ## Public interfaces
 
 - `<AddWordModal onWordAdded>` — button + modal to create a word; calls `onWordAdded()` after a successful save
-- `<EditWordModal word isOpen onClose onWordDeleted>` — read-only word detail panel with a delete action
+- `<EditWordModal word isOpen onClose onWordDeleted onWordUpdated>` — full edit form for all word fields including senses; calls `onWordUpdated` after a successful save and `onWordDeleted` after deletion
 - `<WordTable words onRefresh>` — renders the vocabulary table; calls `onRefresh()` after a deletion
 - `<SearchBar onSearch placeholder? delay?>` — debounced search field; fires `onSearch(value)` after the configured delay
 - `<ThemeToggle />` — self-contained dark/light mode toggle; no props
-- `enrichWord(word: string): Promise<WordEnrichment>` — calls `POST /words/enrich` and returns AI-generated word metadata
-- `wordSchema` — Zod schema for word creation/editing form validation
+- `enrichWord(word: string): Promise<WordEnrichment>` — calls `POST /words/enrich` and returns AI-generated sense-based word metadata
+- `updateWord(wordId: number, data: WordFormValues): Promise<Word>` — calls `PUT /words/{id}` and returns the updated word with full sense graph
+- `wordSchema` — Zod schema for word creation/editing form validation (includes nested `senseSchema`, `grammarPatternSchema`, `exampleSentenceSchema`)
 - `WordFormValues` — TypeScript type inferred from `wordSchema`
-- `Word` — interface matching `WordRead` from the FastAPI backend
-- `WordEnrichment` — interface matching the enrichment response from the FastAPI backend
+- `Word` — interface matching `WordRead` from the FastAPI backend (includes `senses: Sense[]`)
+- `WordEnrichment` — interface matching the enrichment response (includes `senses: Sense[]`)
+- `Sense`, `GrammarPattern`, `ExampleSentence` — interfaces for the nested sense graph
 
 ## External dependencies
 
@@ -45,29 +47,23 @@ A Next.js 16 single-page application that provides the user interface for Vademe
 
 - The backend base URL is hardcoded to `http://localhost:8000` in both `page.tsx` and `lib/api.ts`; no environment-variable abstraction exists yet.
 - Dark mode is initialised by an inline `<script>` in `layout.tsx` that runs before React hydrates, reading `localStorage.theme` and the system `prefers-color-scheme` preference. The `<html>` element has `suppressHydrationWarning` set.
-- `wordSchema` is the single source of truth for form validation — both modals must use it; diverging from it will silently break backend contract alignment.
+- `wordSchema` is the single source of truth for form validation — both `AddWordModal` and `EditWordModal` must use it; diverging will silently break backend contract alignment. The schema includes nested `senseSchema` with `min_length=1` enforced at the Zod layer.
 - Without a search query, the word list is capped at 10 results (`?limit=10`); search results are uncapped.
 
 ## Out of scope
 
 - **Authentication / user accounts** — all vocabulary is global and unauthenticated
-- **Inline editing of words** — EditWordModal is read-only; editing is not yet implemented
+- **Drag-to-reorder senses** — insertion order is preserved; reordering is not implemented
 - **Pagination** — the table shows all search results without paging
 - **Backend persistence logic** — handled entirely by the FastAPI backend and PostgreSQL
 
 ## Changelog
 
-### 2026-05-07 (v0.2.9)
+### 2026-05-09 (v0.3.2)
 
-- Added `BookOpen` logo icon to the app header in `page.tsx` alongside the app name.
-- Standardised row padding to `py-3` across all `WordTable` cells.
-- Changed `shadow-xl` to `shadow-sm` on `AddWordModal` and `EditWordModal` modal containers.
-- Standardised input and select border radius to `rounded-md` in `AddWordModal`.
-- Added missing `dark:focus:ring-forest-400` to the `example_sentences` textarea in `AddWordModal`.
-- Increased `EditWordModal` field row spacing from `space-y-2` to `space-y-3`.
-
-### 2026-05-07 (v0.2.8)
-
-- Muted dark-mode colour palette across `page.tsx`, `WordTable.tsx`, `ThemeToggle.tsx`, `AddWordModal.tsx`, and `SearchBar.tsx`: shifted mid-range `forest-300`–`forest-500` accent text tokens one step lighter to reduce neon-green saturation on dark backgrounds.
-- Added `dark:focus:ring-forest-400` to all form inputs in `AddWordModal` and the search input in `SearchBar`.
-- Corrected stale README constraint: dark-mode flash-of-wrong-theme fix is already implemented in `layout.tsx`.
+- Updated `word.ts`: added `Sense`, `GrammarPattern`, `ExampleSentence` interfaces; extended `Word` with `auxiliary_verb`, `principal_forms`, and `senses`; updated `WordEnrichment` to sense-based shape (removes old flat fields).
+- Updated `wordSchema.ts`: added `grammarPatternSchema`, `exampleSentenceSchema`, `senseSchema`; extended `wordSchema` with `auxiliary_verb`, `principal_forms`, and `senses`; removed top-level `example_sentences`.
+- Updated `api.ts`: added `updateWord(wordId, data)` for `PUT /words/{id}`; added `Word` import.
+- Updated `AddWordModal.tsx`: replaced `example_sentences` textarea with `useFieldArray`-driven senses section; updated `onEnrich` to use `reset()` with the full enriched payload; added optional verb morphology inputs (`auxiliary_verb`, `principal_forms`) shown when `category === "verb"`.
+- Rewrote `EditWordModal.tsx` as a full edit form: RHF + `useFieldArray` for senses, `useEffect` reset on `word` prop change, PUT submit via `updateWord`, Re-enrich button, delete retained; added `onWordUpdated` prop.
+- Updated `WordTable.tsx`: `Meaning` column now shows `senses[0]?.meaning_summary ?? ''`; added `onWordUpdated` prop to `EditWordModal` (wired as `onRefresh`).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/components/AddWordModal.tsx
+++ b/frontend/src/components/AddWordModal.tsx
@@ -1,36 +1,56 @@
 import { enrichWord } from "@/lib/api";
 import { WordFormValues, wordSchema } from "@/lib/wordSchema";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { PlusCircle, Sparkles } from "lucide-react";
+import { PlusCircle, Sparkles, Trash2 } from "lucide-react";
 import { useState } from "react";
-import { useForm } from "react-hook-form";
+import { useFieldArray, useForm } from "react-hook-form";
 
-// Properties how page.tsx talks to AddWordModal
 interface AddWordModalProps {
-  onWordAdded: () => void; // Callback to refresh the table
+  onWordAdded: () => void;
 }
 
+const emptySense: WordFormValues["senses"][number] = {
+  meaning_summary: "",
+  register: "Neutral",
+  grammar_patterns: [{ preposition: null, case: "Akkusativ" }],
+  example_sentences: [{ german: "", english: "" }],
+};
+
+const inputClass =
+  "text-forest-800 dark:text-forest-100 dark:bg-forest-900 border border-forest-300 dark:border-forest-600 w-full p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-forest-500 dark:focus:ring-forest-400";
+
+const labelClass = "text-forest-700 dark:text-forest-100 block text-sm font-medium";
+
 export default function AddWordModal({ onWordAdded }: AddWordModalProps) {
-  // Controls whether to show AddWord UI form (initially set to False -> Not show)
   const [isOpen, setIsOpen] = useState(false);
   const [isEnriching, setIsEnriching] = useState(false);
   const [enrichError, setEnrichError] = useState<string | null>(null);
 
-  // Reach Hook Form
   const {
-    register, // Register input data and apply validation
-    handleSubmit, // Receive form data after validation
-    reset, // Clear form
-    setValue,
+    register,
+    handleSubmit,
+    reset,
     getValues,
     watch,
+    control,
     formState: { errors },
   } = useForm<WordFormValues>({
-    resolver: zodResolver(wordSchema), // Schema validation
-    defaultValues: { gender: "none", category: "noun" },
+    resolver: zodResolver(wordSchema),
+    defaultValues: {
+      gender: "none",
+      category: "noun",
+      senses: [{ ...emptySense }],
+    },
   });
 
-  const wordValue = watch("word"); // drives Enrich button disabled state
+  const { fields: senseFields, append, remove } = useFieldArray({
+    control,
+    name: "senses",
+  });
+
+  const watchedSenses = watch("senses") ?? [];
+  const watchedCategory = watch("category");
+  const wordValue = watch("word");
 
   const onSubmit = async (data: WordFormValues) => {
     try {
@@ -41,9 +61,9 @@ export default function AddWordModal({ onWordAdded }: AddWordModalProps) {
       });
 
       if (response.ok) {
-        reset(); // Clear form
-        setIsOpen(false); // Close the UI form upon submitting new word to be added
-        onWordAdded(); // Trigger table refresh
+        reset({ gender: "none", category: "noun", senses: [{ ...emptySense }] });
+        setIsOpen(false);
+        onWordAdded();
       }
     } catch (error) {
       console.error("Failed to add word:", error);
@@ -54,9 +74,9 @@ export default function AddWordModal({ onWordAdded }: AddWordModalProps) {
    * Click handler for the "Enrich" button.
    *
    * Reads the current word input via getValues("word"), calls enrichWord,
-   * and populates each returned field via setValue. Sets enrichError on failure.
+   * and resets the entire form with the enriched data via reset().
    *
-   * Returns: void — side effects: setValue calls per enriched field, state updates
+   * Returns: void — side effects: reset() call with enriched data, state updates.
    * Does not throw — errors are caught and written to enrichError state.
    */
   const onEnrich = async () => {
@@ -65,15 +85,16 @@ export default function AddWordModal({ onWordAdded }: AddWordModalProps) {
     setEnrichError(null);
     try {
       const enriched = await enrichWord(word);
-      setValue("translation", enriched.translation);
-      setValue("gender", enriched.gender);
-      setValue("category", enriched.category);
-      if (enriched.word_plural !== null) {
-        setValue("word_plural", enriched.word_plural);
-      }
-      if (enriched.example_sentences !== null) {
-        setValue("example_sentences", enriched.example_sentences);
-      }
+      reset({
+        word,
+        translation: enriched.translation,
+        gender: enriched.gender,
+        category: enriched.category,
+        word_plural: enriched.word_plural ?? undefined,
+        auxiliary_verb: enriched.auxiliary_verb ?? undefined,
+        principal_forms: enriched.principal_forms ?? undefined,
+        senses: enriched.senses,
+      });
     } catch {
       setEnrichError("Could not enrich word. Please try again.");
     } finally {
@@ -92,20 +113,19 @@ export default function AddWordModal({ onWordAdded }: AddWordModalProps) {
 
       {isOpen && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-          <div className="bg-white dark:bg-forest-800 p-6 rounded-xl shadow-sm w-full max-w-md">
-            <h2 className="text-forest-800 dark:text-forest-100 text-xl font-bold mb-4">
+          <div className="bg-white dark:bg-forest-800 p-6 rounded-xl shadow-sm w-full max-w-lg max-h-[90vh] flex flex-col">
+            <h2 className="text-forest-800 dark:text-forest-100 text-xl font-bold mb-4 shrink-0">
               Add German Word
             </h2>
-            <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+            <form
+              onSubmit={handleSubmit(onSubmit)}
+              className="space-y-4 overflow-y-auto flex-1 pr-1"
+            >
+              {/* German Word + Enrich */}
               <div>
-                <label className="text-forest-700 dark:text-forest-100 block text-sm font-medium">
-                  German Word
-                </label>
+                <label className={labelClass}>German Word</label>
                 <div className="flex gap-2 mt-1">
-                  <input
-                    {...register("word")}
-                    className="text-forest-800 dark:text-forest-100 dark:bg-forest-900 border border-forest-300 dark:border-forest-600 w-full p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-forest-500 dark:focus:ring-forest-400"
-                  />
+                  <input {...register("word")} className={inputClass} />
                   <button
                     type="button"
                     onClick={onEnrich}
@@ -117,39 +137,27 @@ export default function AddWordModal({ onWordAdded }: AddWordModalProps) {
                   </button>
                 </div>
                 {errors.word && (
-                  <p className="text-red-600 text-xs mt-1">
-                    {errors.word.message}
-                  </p>
+                  <p className="text-red-600 text-xs mt-1">{errors.word.message}</p>
                 )}
                 {enrichError && (
                   <p className="text-red-500 text-xs mt-1">{enrichError}</p>
                 )}
               </div>
 
+              {/* Translation */}
               <div>
-                <label className="text-forest-700 dark:text-forest-100 block text-sm font-medium">
-                  Translation
-                </label>
-                <input
-                  {...register("translation")}
-                  className="text-forest-800 dark:text-forest-100 dark:bg-forest-900 border border-forest-300 dark:border-forest-600 w-full p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-forest-500 dark:focus:ring-forest-400"
-                />
+                <label className={labelClass}>Translation</label>
+                <input {...register("translation")} className={inputClass} />
                 {errors.translation && (
-                  <p className="text-red-500 text-xs">
-                    {errors.translation.message}
-                  </p>
+                  <p className="text-red-500 text-xs">{errors.translation.message}</p>
                 )}
               </div>
 
+              {/* Gender + Category */}
               <div className="flex gap-4">
                 <div className="flex-1">
-                  <label className="text-forest-700 dark:text-forest-100 block text-sm font-medium">
-                    Gender
-                  </label>
-                  <select
-                    {...register("gender")}
-                    className="text-forest-800 dark:text-forest-100 dark:bg-forest-900 border border-forest-300 dark:border-forest-600 w-full p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-forest-500 dark:focus:ring-forest-400"
-                  >
+                  <label className={labelClass}>Gender</label>
+                  <select {...register("gender")} className={inputClass}>
                     <option value="none">none</option>
                     <option value="der">der</option>
                     <option value="die">die</option>
@@ -157,13 +165,8 @@ export default function AddWordModal({ onWordAdded }: AddWordModalProps) {
                   </select>
                 </div>
                 <div className="flex-1">
-                  <label className="text-forest-700 dark:text-forest-100 block text-sm font-medium">
-                    Category
-                  </label>
-                  <select
-                    {...register("category")}
-                    className="text-forest-800 dark:text-forest-100 dark:bg-forest-900 border border-forest-300 dark:border-forest-600 w-full p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-forest-500 dark:focus:ring-forest-400"
-                  >
+                  <label className={labelClass}>Category</label>
+                  <select {...register("category")} className={inputClass}>
                     <option value="noun">noun</option>
                     <option value="verb">verb</option>
                     <option value="adjective">adjective</option>
@@ -173,28 +176,175 @@ export default function AddWordModal({ onWordAdded }: AddWordModalProps) {
                 </div>
               </div>
 
+              {/* Plural */}
               <div>
-                <label className="text-forest-700 dark:text-forest-100 block text-sm font-medium">
-                  Plural
-                </label>
-                <input
-                  {...register("word_plural")}
-                  className="text-forest-800 dark:text-forest-100 dark:bg-forest-900 border border-forest-300 dark:border-forest-600 w-full p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-forest-500 dark:focus:ring-forest-400"
-                />
+                <label className={labelClass}>Plural</label>
+                <input {...register("word_plural")} className={inputClass} />
               </div>
 
+              {/* Verb Morphology — shown only for verbs */}
+              {watchedCategory === "verb" && (
+                <div className="border border-forest-200 dark:border-forest-600 rounded-lg p-3 space-y-3">
+                  <p className="text-xs font-semibold text-forest-600 dark:text-forest-300 uppercase tracking-wide">
+                    Verb Morphology
+                  </p>
+                  <div>
+                    <label className={labelClass}>Auxiliary Verb</label>
+                    <select {...register("auxiliary_verb")} className={inputClass}>
+                      <option value="">—</option>
+                      <option value="haben">haben</option>
+                      <option value="sein">sein</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label className={labelClass}>Principal Forms</label>
+                    <div className="grid grid-cols-3 gap-2 mt-1">
+                      {["Infinitiv", "Präteritum", "Partizip II"].map((label, i) => (
+                        <div key={label}>
+                          <p className="text-xs text-forest-500 dark:text-forest-400 mb-1">
+                            {label}
+                          </p>
+                          <input
+                            {...register(`principal_forms.${i}`)}
+                            className={inputClass}
+                          />
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* Senses */}
               <div>
-                <label className="text-forest-700 dark:text-forest-100 block text-sm font-medium">
-                  Example Sentences
-                </label>
-                <textarea
-                  {...register("example_sentences")}
-                  rows={2}
-                  className="text-forest-800 dark:text-forest-100 dark:bg-forest-900 border border-forest-300 dark:border-forest-600 w-full p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-forest-500 dark:focus:ring-forest-400 resize-none"
-                />
+                <div className="flex items-center justify-between mb-2">
+                  <label className={labelClass}>Senses</label>
+                  <button
+                    type="button"
+                    onClick={() => append({ ...emptySense })}
+                    className="text-xs text-forest-600 dark:text-forest-300 hover:text-forest-800 dark:hover:text-forest-100 flex items-center gap-1"
+                  >
+                    <PlusCircle className="w-3 h-3" /> Add Sense
+                  </button>
+                </div>
+                {errors.senses && !Array.isArray(errors.senses) && (
+                  <p className="text-red-500 text-xs mb-2">
+                    {errors.senses.message}
+                  </p>
+                )}
+
+                <div className="space-y-4">
+                  {senseFields.map((field, sIdx) => (
+                    <div
+                      key={field.id}
+                      className="border border-forest-200 dark:border-forest-600 rounded-lg p-3 space-y-3"
+                    >
+                      <div className="flex items-center justify-between">
+                        <p className="text-xs font-semibold text-forest-600 dark:text-forest-300 uppercase tracking-wide">
+                          Sense {sIdx + 1}
+                        </p>
+                        <button
+                          type="button"
+                          onClick={() => remove(sIdx)}
+                          disabled={senseFields.length === 1}
+                          className="text-red-400 hover:text-red-600 disabled:opacity-30 disabled:cursor-not-allowed"
+                        >
+                          <Trash2 className="w-3 h-3" />
+                        </button>
+                      </div>
+
+                      {/* Meaning Summary */}
+                      <div>
+                        <label className={labelClass}>Meaning Summary</label>
+                        <input
+                          {...register(`senses.${sIdx}.meaning_summary`)}
+                          className={inputClass}
+                        />
+                        {errors.senses?.[sIdx]?.meaning_summary && (
+                          <p className="text-red-500 text-xs">
+                            {errors.senses[sIdx].meaning_summary?.message}
+                          </p>
+                        )}
+                      </div>
+
+                      {/* Register */}
+                      <div>
+                        <label className={labelClass}>Register</label>
+                        <select
+                          {...register(`senses.${sIdx}.register`)}
+                          className={inputClass}
+                        >
+                          <option value="Neutral">Neutral</option>
+                          <option value="Formal">Formal</option>
+                          <option value="Colloquial">Colloquial</option>
+                          <option value="Technical">Technical</option>
+                        </select>
+                      </div>
+
+                      {/* Grammar Patterns */}
+                      <div>
+                        <p className="text-xs font-medium text-forest-600 dark:text-forest-300 mb-1">
+                          Grammar Patterns
+                        </p>
+                        {(watchedSenses[sIdx]?.grammar_patterns ?? []).map(
+                          (_, gpIdx) => (
+                            <div key={gpIdx} className="flex gap-2 mt-1">
+                              <input
+                                {...register(
+                                  `senses.${sIdx}.grammar_patterns.${gpIdx}.preposition`,
+                                )}
+                                placeholder="Preposition (optional)"
+                                className={inputClass}
+                              />
+                              <select
+                                {...register(
+                                  `senses.${sIdx}.grammar_patterns.${gpIdx}.case`,
+                                )}
+                                className={inputClass}
+                              >
+                                <option value="Akkusativ">Akkusativ</option>
+                                <option value="Dativ">Dativ</option>
+                                <option value="Nominativ">Nominativ</option>
+                                <option value="Genitiv">Genitiv</option>
+                              </select>
+                            </div>
+                          ),
+                        )}
+                      </div>
+
+                      {/* Example Sentences */}
+                      <div>
+                        <p className="text-xs font-medium text-forest-600 dark:text-forest-300 mb-1">
+                          Example Sentences
+                        </p>
+                        {(watchedSenses[sIdx]?.example_sentences ?? []).map(
+                          (_, exIdx) => (
+                            <div key={exIdx} className="space-y-1 mt-1">
+                              <input
+                                {...register(
+                                  `senses.${sIdx}.example_sentences.${exIdx}.german`,
+                                )}
+                                placeholder="German sentence"
+                                className={inputClass}
+                              />
+                              <input
+                                {...register(
+                                  `senses.${sIdx}.example_sentences.${exIdx}.english`,
+                                )}
+                                placeholder="English translation"
+                                className={inputClass}
+                              />
+                            </div>
+                          ),
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </div>
               </div>
 
-              <div className="flex justify-end gap-3 mt-6">
+              {/* Actions */}
+              <div className="flex justify-end gap-3 pt-2 shrink-0">
                 <button
                   type="button"
                   onClick={() => setIsOpen(false)}

--- a/frontend/src/components/EditWordModal.tsx
+++ b/frontend/src/components/EditWordModal.tsx
@@ -1,21 +1,95 @@
-// frontend/src/components/EditWordModal.tsx
+import { enrichWord, updateWord } from "@/lib/api";
+import { WordFormValues, wordSchema } from "@/lib/wordSchema";
 import { Word } from "@/types/word";
-import { Trash2 } from "lucide-react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { PlusCircle, RefreshCw, Trash2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useFieldArray, useForm } from "react-hook-form";
 
-// Props for WordTable.tsx to interact with EditWordModel Component
 interface EditWordModalProps {
   word: Word;
   isOpen: boolean;
   onClose: () => void;
   onWordDeleted: () => void;
+  onWordUpdated: () => void;
 }
+
+function buildDefaultValues(word: Word): WordFormValues {
+  return {
+    word: word.word,
+    translation: word.translation,
+    gender: (word.gender as WordFormValues["gender"]) ?? "none",
+    category: (word.category as WordFormValues["category"]) ?? "noun",
+    word_plural: word.word_plural ?? undefined,
+    auxiliary_verb: word.auxiliary_verb ?? undefined,
+    principal_forms: word.principal_forms ?? undefined,
+    senses: word.senses.map((s) => ({
+      meaning_summary: s.meaning_summary,
+      register: s.register,
+      grammar_patterns: s.grammar_patterns.map((gp) => ({
+        preposition: gp.preposition,
+        case: gp.case,
+      })),
+      example_sentences: s.example_sentences.map((ex) => ({
+        german: ex.german,
+        english: ex.english,
+      })),
+    })),
+  };
+}
+
+const emptySense: WordFormValues["senses"][number] = {
+  meaning_summary: "",
+  register: "Neutral",
+  grammar_patterns: [{ preposition: null, case: "Akkusativ" }],
+  example_sentences: [{ german: "", english: "" }],
+};
+
+const inputClass =
+  "text-forest-800 dark:text-forest-100 dark:bg-forest-900 border border-forest-300 dark:border-forest-600 w-full p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-forest-500 dark:focus:ring-forest-400";
+
+const labelClass = "text-forest-700 dark:text-forest-100 block text-sm font-medium";
 
 export default function EditWordModal({
   word,
   isOpen,
   onClose,
   onWordDeleted,
+  onWordUpdated,
 }: EditWordModalProps) {
+  // All hooks must be declared before any early return
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isEnriching, setIsEnriching] = useState(false);
+  const [enrichError, setEnrichError] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    getValues,
+    watch,
+    control,
+    formState: { errors },
+  } = useForm<WordFormValues>({
+    resolver: zodResolver(wordSchema),
+    defaultValues: buildDefaultValues(word),
+  });
+
+  const { fields: senseFields, append, remove } = useFieldArray({
+    control,
+    name: "senses",
+  });
+
+  // Reset form whenever the selected word changes
+  useEffect(() => {
+    reset(buildDefaultValues(word));
+  }, [word, reset]);
+
+  const watchedSenses = watch("senses") ?? [];
+  const watchedCategory = watch("category");
+
+  // Guard comes after all hooks
   if (!isOpen) return null;
 
   const handleDelete = async () => {
@@ -27,68 +101,319 @@ export default function EditWordModal({
       });
 
       if (response.ok) {
-        onWordDeleted(); // Refresh the table
-        onClose(); // Close the modal
+        onWordDeleted();
+        onClose();
       }
     } catch (error) {
       console.error("Delete failed:", error);
     }
   };
 
+  const onSubmit = async (data: WordFormValues) => {
+    setIsSubmitting(true);
+    setSubmitError(null);
+    try {
+      await updateWord(word.id, data);
+      onWordUpdated();
+      onClose();
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "Update failed.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const onReEnrich = async () => {
+    const currentWord = getValues("word");
+    setIsEnriching(true);
+    setEnrichError(null);
+    try {
+      const enriched = await enrichWord(currentWord);
+      reset({
+        word: currentWord,
+        translation: enriched.translation,
+        gender: enriched.gender,
+        category: enriched.category,
+        word_plural: enriched.word_plural ?? undefined,
+        auxiliary_verb: enriched.auxiliary_verb ?? undefined,
+        principal_forms: enriched.principal_forms ?? undefined,
+        senses: enriched.senses,
+      });
+    } catch {
+      setEnrichError("Could not re-enrich word. Please try again.");
+    } finally {
+      setIsEnriching(false);
+    }
+  };
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="bg-white dark:bg-forest-800 p-6 rounded-xl shadow-sm w-full max-w-md">
-        <h2 className="text-forest-700 dark:text-forest-200 text-xl font-bold mb-4">
-          Word Details
+      <div className="bg-white dark:bg-forest-800 p-6 rounded-xl shadow-sm w-full max-w-lg max-h-[90vh] flex flex-col">
+        <h2 className="text-forest-700 dark:text-forest-200 text-xl font-bold mb-4 shrink-0">
+          Edit Word
         </h2>
 
-        <div className="space-y-3 mb-6">
-          <p>
-            <strong className="text-forest-700 dark:text-forest-300">
-              German:
-            </strong>{" "}
-            <span className="text-forest-900 dark:text-forest-100">
-              {word.word}
-            </span>{" "}
-            {word.gender !== "none" && (
-              <span className="text-forest-500 dark:text-forest-400 text-xs uppercase">
-                ({word.gender})
-              </span>
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className="space-y-4 overflow-y-auto flex-1 pr-1"
+        >
+          {/* German Word + Re-enrich */}
+          <div>
+            <label className={labelClass}>German Word</label>
+            <div className="flex gap-2 mt-1">
+              <input {...register("word")} className={inputClass} />
+              <button
+                type="button"
+                onClick={onReEnrich}
+                disabled={isEnriching || isSubmitting}
+                className="flex items-center gap-1 px-3 py-2 rounded bg-forest-100 dark:bg-forest-700 text-forest-700 dark:text-forest-200 hover:bg-forest-200 dark:hover:bg-forest-600 transition-colors disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap text-xs"
+              >
+                <RefreshCw className="w-3 h-3" />
+                {isEnriching ? "Enriching…" : "Re-enrich (replaces senses)"}
+              </button>
+            </div>
+            {errors.word && (
+              <p className="text-red-600 text-xs mt-1">{errors.word.message}</p>
             )}
-          </p>
-          <p>
-            <strong className="text-forest-700 dark:text-forest-300">
-              Translation:
-            </strong>{" "}
-            <span className="text-forest-900 dark:text-forest-100">
-              {word.translation}
-            </span>
-          </p>
-          <p>
-            <strong className="text-forest-700 dark:text-forest-300">
-              Category:
-            </strong>{" "}
-            <span className="text-forest-900 dark:text-forest-100">
-              {word.category}
-            </span>
-          </p>
-        </div>
+            {enrichError && (
+              <p className="text-red-500 text-xs mt-1">{enrichError}</p>
+            )}
+          </div>
 
-        <div className="flex justify-between items-center mt-6">
-          <button
-            onClick={handleDelete}
-            className="flex items-center gap-2 text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 px-3 py-2 rounded-lg transition-colors"
-          >
-            <Trash2 className="w-4 h-4" /> Delete Word
-          </button>
+          {/* Translation */}
+          <div>
+            <label className={labelClass}>Translation</label>
+            <input {...register("translation")} className={inputClass} />
+            {errors.translation && (
+              <p className="text-red-500 text-xs">{errors.translation.message}</p>
+            )}
+          </div>
 
-          <button
-            onClick={onClose}
-            className="bg-forest-100 dark:bg-forest-700 text-forest-800 dark:text-forest-100 hover:bg-forest-200 dark:hover:bg-forest-600 px-4 py-2 rounded-lg transition-colors"
-          >
-            Close
-          </button>
-        </div>
+          {/* Gender + Category */}
+          <div className="flex gap-4">
+            <div className="flex-1">
+              <label className={labelClass}>Gender</label>
+              <select {...register("gender")} className={inputClass}>
+                <option value="none">none</option>
+                <option value="der">der</option>
+                <option value="die">die</option>
+                <option value="das">das</option>
+              </select>
+            </div>
+            <div className="flex-1">
+              <label className={labelClass}>Category</label>
+              <select {...register("category")} className={inputClass}>
+                <option value="noun">noun</option>
+                <option value="verb">verb</option>
+                <option value="adjective">adjective</option>
+                <option value="adverb">adverb</option>
+                <option value="pronoun">pronoun</option>
+              </select>
+            </div>
+          </div>
+
+          {/* Plural */}
+          <div>
+            <label className={labelClass}>Plural</label>
+            <input {...register("word_plural")} className={inputClass} />
+          </div>
+
+          {/* Verb Morphology — shown only when auxiliary_verb is set or category is verb */}
+          {(watchedCategory === "verb" || word.auxiliary_verb) && (
+            <div className="border border-forest-200 dark:border-forest-600 rounded-lg p-3 space-y-3">
+              <p className="text-xs font-semibold text-forest-600 dark:text-forest-300 uppercase tracking-wide">
+                Verb Morphology
+              </p>
+              <div>
+                <label className={labelClass}>Auxiliary Verb</label>
+                <select {...register("auxiliary_verb")} className={inputClass}>
+                  <option value="">—</option>
+                  <option value="haben">haben</option>
+                  <option value="sein">sein</option>
+                </select>
+              </div>
+              <div>
+                <label className={labelClass}>Principal Forms</label>
+                <div className="grid grid-cols-3 gap-2 mt-1">
+                  {["Infinitiv", "Präteritum", "Partizip II"].map((label, i) => (
+                    <div key={label}>
+                      <p className="text-xs text-forest-500 dark:text-forest-400 mb-1">
+                        {label}
+                      </p>
+                      <input
+                        {...register(`principal_forms.${i}`)}
+                        className={inputClass}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {/* Senses */}
+          <div>
+            <div className="flex items-center justify-between mb-2">
+              <label className={labelClass}>Senses</label>
+              <button
+                type="button"
+                onClick={() => append({ ...emptySense })}
+                className="text-xs text-forest-600 dark:text-forest-300 hover:text-forest-800 dark:hover:text-forest-100 flex items-center gap-1"
+              >
+                <PlusCircle className="w-3 h-3" /> Add Sense
+              </button>
+            </div>
+            {errors.senses && !Array.isArray(errors.senses) && (
+              <p className="text-red-500 text-xs mb-2">
+                {errors.senses.message}
+              </p>
+            )}
+
+            <div className="space-y-4">
+              {senseFields.map((field, sIdx) => (
+                <div
+                  key={field.id}
+                  className="border border-forest-200 dark:border-forest-600 rounded-lg p-3 space-y-3"
+                >
+                  <div className="flex items-center justify-between">
+                    <p className="text-xs font-semibold text-forest-600 dark:text-forest-300 uppercase tracking-wide">
+                      Sense {sIdx + 1}
+                    </p>
+                    <button
+                      type="button"
+                      onClick={() => remove(sIdx)}
+                      disabled={senseFields.length === 1}
+                      className="text-red-400 hover:text-red-600 disabled:opacity-30 disabled:cursor-not-allowed"
+                    >
+                      <Trash2 className="w-3 h-3" />
+                    </button>
+                  </div>
+
+                  {/* Meaning Summary */}
+                  <div>
+                    <label className={labelClass}>Meaning Summary</label>
+                    <input
+                      {...register(`senses.${sIdx}.meaning_summary`)}
+                      className={inputClass}
+                    />
+                    {errors.senses?.[sIdx]?.meaning_summary && (
+                      <p className="text-red-500 text-xs">
+                        {errors.senses[sIdx].meaning_summary?.message}
+                      </p>
+                    )}
+                  </div>
+
+                  {/* Register */}
+                  <div>
+                    <label className={labelClass}>Register</label>
+                    <select
+                      {...register(`senses.${sIdx}.register`)}
+                      className={inputClass}
+                    >
+                      <option value="Neutral">Neutral</option>
+                      <option value="Formal">Formal</option>
+                      <option value="Colloquial">Colloquial</option>
+                      <option value="Technical">Technical</option>
+                    </select>
+                  </div>
+
+                  {/* Grammar Patterns */}
+                  <div>
+                    <p className="text-xs font-medium text-forest-600 dark:text-forest-300 mb-1">
+                      Grammar Patterns
+                    </p>
+                    {(watchedSenses[sIdx]?.grammar_patterns ?? []).map(
+                      (_, gpIdx) => (
+                        <div key={gpIdx} className="flex gap-2 mt-1">
+                          <input
+                            {...register(
+                              `senses.${sIdx}.grammar_patterns.${gpIdx}.preposition`,
+                            )}
+                            placeholder="Preposition (optional)"
+                            className={inputClass}
+                          />
+                          <select
+                            {...register(
+                              `senses.${sIdx}.grammar_patterns.${gpIdx}.case`,
+                            )}
+                            className={inputClass}
+                          >
+                            <option value="Akkusativ">Akkusativ</option>
+                            <option value="Dativ">Dativ</option>
+                            <option value="Nominativ">Nominativ</option>
+                            <option value="Genitiv">Genitiv</option>
+                          </select>
+                        </div>
+                      ),
+                    )}
+                  </div>
+
+                  {/* Example Sentences */}
+                  <div>
+                    <p className="text-xs font-medium text-forest-600 dark:text-forest-300 mb-1">
+                      Example Sentences
+                    </p>
+                    {(watchedSenses[sIdx]?.example_sentences ?? []).map(
+                      (_, exIdx) => (
+                        <div key={exIdx} className="space-y-1 mt-1">
+                          <input
+                            {...register(
+                              `senses.${sIdx}.example_sentences.${exIdx}.german`,
+                            )}
+                            placeholder="German sentence"
+                            className={inputClass}
+                          />
+                          <input
+                            {...register(
+                              `senses.${sIdx}.example_sentences.${exIdx}.english`,
+                            )}
+                            placeholder="English translation"
+                            className={inputClass}
+                          />
+                        </div>
+                      ),
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Submit error */}
+          {submitError && (
+            <p className="text-red-500 text-sm">{submitError}</p>
+          )}
+
+          {/* Actions */}
+          <div className="flex justify-between items-center pt-2 shrink-0">
+            <button
+              type="button"
+              onClick={handleDelete}
+              disabled={isSubmitting}
+              className="flex items-center gap-2 text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 px-3 py-2 rounded-lg transition-colors disabled:opacity-40"
+            >
+              <Trash2 className="w-4 h-4" /> Delete Word
+            </button>
+
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={isSubmitting}
+                className="text-forest-600 dark:text-forest-200 hover:text-forest-800 dark:hover:text-forest-100 transition-colors disabled:opacity-40"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={isSubmitting}
+                className="bg-forest-600 hover:bg-forest-700 text-white px-4 py-2 rounded transition-colors disabled:opacity-60"
+              >
+                {isSubmitting ? "Saving…" : "Save Changes"}
+              </button>
+            </div>
+          </div>
+        </form>
       </div>
     </div>
   );

--- a/frontend/src/components/WordTable.tsx
+++ b/frontend/src/components/WordTable.tsx
@@ -2,16 +2,14 @@
 import { Word } from "@/types/word";
 import { BookOpen, Clock, Languages } from "lucide-react";
 import { useState } from "react";
-import EditWordModal from "./EditWordModal"; // Ensure you create this file next
+import EditWordModal from "./EditWordModal";
 
-// 1. Updated Props to include onRefresh callback
 interface WordTableProps {
   words: Word[];
   onRefresh: () => void;
 }
 
 export default function WordTable({ words, onRefresh }: WordTableProps) {
-  // 2. State to track which word is currently selected for the Modal
   const [selectedWord, setSelectedWord] = useState<Word | null>(null);
 
   return (
@@ -27,7 +25,7 @@ export default function WordTable({ words, onRefresh }: WordTableProps) {
               </th>
               <th className="px-3 py-3.5 text-left text-sm font-semibold text-forest-900 dark:text-forest-100">
                 <div className="flex items-center gap-2">
-                  <BookOpen className="w-4 h-4" /> Translation
+                  <BookOpen className="w-4 h-4" /> Meaning
                 </div>
               </th>
               <th className="px-3 py-3.5 text-left text-sm font-semibold text-forest-900 dark:text-forest-100">
@@ -44,7 +42,6 @@ export default function WordTable({ words, onRefresh }: WordTableProps) {
             {words.map((word) => (
               <tr
                 key={word.id}
-                // 3. Make row clickable to open details/edit/delete modal
                 onClick={() => setSelectedWord(word)}
                 className="hover:bg-forest-50 dark:hover:bg-forest-800 cursor-pointer transition-colors"
               >
@@ -59,7 +56,7 @@ export default function WordTable({ words, onRefresh }: WordTableProps) {
                   )}
                 </td>
                 <td className="whitespace-nowrap px-3 py-3 text-sm text-forest-600 dark:text-forest-200">
-                  {word.translation}
+                  {word.senses?.[0]?.meaning_summary ?? ""}
                 </td>
                 <td className="whitespace-nowrap px-3 py-3 text-sm">
                   <span className="inline-flex items-center rounded-md bg-forest-50 dark:bg-forest-700 px-2 py-1 text-xs font-medium text-forest-700 dark:text-forest-100 ring-1 ring-inset ring-forest-700/10 dark:ring-forest-300/20">
@@ -75,13 +72,13 @@ export default function WordTable({ words, onRefresh }: WordTableProps) {
         </table>
       </div>
 
-      {/* 4. The Edit/Delete Modal: Only renders when a word is selected */}
       {selectedWord && (
         <EditWordModal
           word={selectedWord}
           isOpen={!!selectedWord}
           onClose={() => setSelectedWord(null)}
           onWordDeleted={onRefresh}
+          onWordUpdated={onRefresh}
         />
       )}
     </>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,5 @@
-import { WordEnrichment } from "@/types/word";
+import { Word, WordEnrichment } from "@/types/word";
+import { WordFormValues } from "@/lib/wordSchema";
 
 /**
  * Call POST /words/enrich and return the enriched word metadata.
@@ -19,4 +20,33 @@ export async function enrichWord(word: string): Promise<WordEnrichment> {
   }
 
   return response.json() as Promise<WordEnrichment>;
+}
+
+/**
+ * Call PUT /words/{wordId} and return the updated word.
+ *
+ * @param wordId - The ID of the word to update.
+ * @param payload - The updated word data conforming to WordFormValues.
+ * @returns The updated Word object with the full sense graph.
+ * @throws Error if the HTTP response status is not ok (4xx / 5xx).
+ */
+export async function updateWord(
+  wordId: number,
+  payload: WordFormValues,
+): Promise<Word> {
+  const response = await fetch(`http://localhost:8000/words/${wordId}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const detail = await response.json().catch(() => ({}));
+    throw new Error(
+      (detail as { detail?: string }).detail ??
+        `Update failed: ${response.status}`,
+    );
+  }
+
+  return response.json() as Promise<Word>;
 }

--- a/frontend/src/lib/wordSchema.ts
+++ b/frontend/src/lib/wordSchema.ts
@@ -1,20 +1,33 @@
 // Runtime Validation
 import { z } from "zod";
 
+export const grammarPatternSchema = z.object({
+  preposition: z.string().nullable().optional(),
+  case: z.enum(["Nominativ", "Akkusativ", "Dativ", "Genitiv"]),
+});
+
+export const exampleSentenceSchema = z.object({
+  german: z.string().min(1, "German sentence is required"),
+  english: z.string().min(1, "English translation is required"),
+});
+
+export const senseSchema = z.object({
+  meaning_summary: z.string().min(1, "Meaning summary is required"),
+  register: z.enum(["Formal", "Colloquial", "Neutral", "Technical"]),
+  grammar_patterns: z.array(grammarPatternSchema).min(1),
+  example_sentences: z.array(exampleSentenceSchema).min(1),
+});
+
 export const wordSchema = z.object({
   word: z.string().min(1, "German word is required"),
   translation: z.string().min(1, "Translation is required"),
   gender: z.enum(["der", "die", "das", "none"]),
-  category: z.enum([
-    "noun",
-    "verb",
-    "adjective",
-    "adverb",
-    "pronoun",
-  ]),
+  category: z.enum(["noun", "verb", "adjective", "adverb", "pronoun"]),
   word_plural: z.string().optional(),
-  example_sentences: z.string().optional(),
+  auxiliary_verb: z.string().optional(),
+  principal_forms: z.array(z.string()).optional(),
+  senses: z.array(senseSchema).min(1, "At least one sense is required"),
 });
 
-// Generate a TypeScript Type Interface to be used in AddWordModal.tsx
+// Generate a TypeScript Type Interface to be used in AddWordModal.tsx and EditWordModal.tsx
 export type WordFormValues = z.infer<typeof wordSchema>;

--- a/frontend/src/types/word.ts
+++ b/frontend/src/types/word.ts
@@ -1,3 +1,23 @@
+export interface GrammarPattern {
+  id?: number;
+  preposition: string | null;
+  case: "Nominativ" | "Akkusativ" | "Dativ" | "Genitiv";
+}
+
+export interface ExampleSentence {
+  id?: number;
+  german: string;
+  english: string;
+}
+
+export interface Sense {
+  id?: number;
+  meaning_summary: string;
+  register: "Formal" | "Colloquial" | "Neutral" | "Technical";
+  grammar_patterns: GrammarPattern[];
+  example_sentences: ExampleSentence[];
+}
+
 /**
  * This interface matches the 'WordRead' schema from FastAPI backend.
  * It ensures TypeScript knows that every word from the DB has these exact fields.
@@ -6,9 +26,15 @@ export interface Word {
   id: number;
   word: string;
   gender?: string;
+  word_nominative?: string | null;
+  word_genitive?: string | null;
+  word_plural?: string | null;
   translation: string;
   category?: string;
+  auxiliary_verb?: string | null;
+  principal_forms?: string[] | null;
   created_at: string;
+  senses: Sense[];
 }
 
 /**
@@ -22,7 +48,7 @@ export interface WordEnrichment {
   word_plural: string | null;
   translation: string;
   category: "noun" | "verb" | "adjective" | "adverb" | "pronoun";
-  prepositions: string | null;
-  example_sentences: string | null;
-  idiomatic_usages: string | null;
+  auxiliary_verb: string | null;
+  principal_forms: string[] | null;
+  senses: Sense[];
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vademecum-germanicum"
-version = "0.3.1"
+version = "0.3.2"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Description

The PR resolves the issue #37 by refactor the frontend with the new Data Model structure.

## Changelog

### Added

- **Frontend**: `Sense`, `GrammarPattern`, `ExampleSentence` TypeScript interfaces in `word.ts` mirroring the new backend sense graph.
- **Frontend**: `grammarPatternSchema`, `exampleSentenceSchema`, `senseSchema` Zod schemas in `wordSchema.ts`; `wordSchema` extended with `auxiliary_verb`, `principal_forms`, and `senses` (min 1).
- **Frontend**: `updateWord(wordId, data)` API helper in `api.ts` calling `PUT /words/{id}`.

### Changed

- **Frontend**: `AddWordModal` updated to sense-based form — `example_sentences` textarea replaced by `useFieldArray`-driven senses section; `onEnrich` now uses `reset()` with the full enrichment payload; optional verb morphology inputs (`auxiliary_verb`, `principal_forms`) shown when `category === "verb"`.
- **Frontend**: `EditWordModal` rewritten as a full edit form — RHF + `useFieldArray` for senses, `useEffect` reset on word prop change, PUT submit, Re-enrich button, `onWordUpdated` callback; `isOpen` guard moved after all hook declarations.
- **Frontend**: `WordTable` "Meaning" column now displays `senses[0]?.meaning_summary ?? ''`; `onWordUpdated` prop added to `EditWordModal` and wired as `onRefresh`.
- **Frontend**: `Word` and `WordEnrichment` interfaces updated to sense-based structure — `Word` gains `auxiliary_verb`, `principal_forms`, `senses`; `WordEnrichment` drops old flat fields and gains `auxiliary_verb`, `principal_forms`, `senses`.

## Checklist

### Mandatory

- [x] The title of the Pull Request starts with the JIRA ticket number (if provided)
- [x] The title of the Pull Request must reflect the corresponding issue title
- [x] It has to have a `Description` section, specifying which is the `#issue` it's resolving and how
- [x] It has to have a `Changelog` section, reporting what has been changed in the corresponding issue
- [x] The project version must have been updated

### Optional

- [x] Update the Wiki
- [x] Update the `README.md`
- [x] Update the `CHANGELOG.md`
