### PR TITLE
feat/Collapsible- sense cards

### DIFF
--- a/.claude/planning/4-collapsable-cards/48-collapsible-sense-cards.md
+++ b/.claude/planning/4-collapsable-cards/48-collapsible-sense-cards.md
@@ -1,0 +1,183 @@
+# #48: Collapsible Sense Cards
+
+**GitHub Issue:** [#48 — Collapsible Sense Cards](https://github.com/Volscente/vademecum-germanicum/issues/48)
+**GitHub Milestone:** [4-collapsable-cards](https://github.com/Volscente/vademecum-germanicum/milestone/4-collapsable-cards)
+**Notion page:** [4-Collapsable Cards](https://www.notion.so/4-Collapsable-Cards-35c5cc6c0f0780fcaf30f0929b928375)
+
+---
+
+## Technical Scope
+
+**In scope:**
+
+- `frontend/src/components/EditWordModal.tsx` — add `sensesCollapsed: boolean[]` local state; `useEffect` to sync array length with `fields.length` from `useFieldArray`; per-sense toggle handler; collapsed card header (ChevronDown/ChevronUp icon, Meaning Summary text, error badge); CSS max-height collapse on each Sense card body
+
+**Out of scope:**
+
+- `frontend/src/lib/wordSchema.ts` — no schema changes required
+- `frontend/src/lib/api.ts` — no API changes required
+- `frontend/src/types/word.ts` — no type changes required
+- `frontend/src/components/AddWordModal.tsx` — not touched
+- Global "Collapse All" button (TASK-3 / Issue #49)
+
+---
+
+## Architecture
+
+```txt
+EditWordModal.tsx
+│
+├── verbMorphologyCollapsed: boolean          ← already in place (TASK-1 / v0.3.3)
+├── sensesCollapsed: boolean[]               ← NEW
+│   └── useEffect([fields.length])           ← grow/truncate on append / remove / Re-enrich reset
+│
+├── fields (useFieldArray on "senses")
+│   └── fields[n] — one entry per Sense
+│
+└── JSX: fields.map((field, n) => ...)
+       │
+       ├── Card Header (always rendered)
+       │   ├── ChevronDown / ChevronUp icon  ← onClick: toggleSenseCollapsed(n)
+       │   ├── "Sense {n+1}" title
+       │   ├── watch(`senses.${n}.meaning_summary`) or "No summary yet"  ← shown when collapsed
+       │   └── red dot badge if !!errors.senses?.[n] && sensesCollapsed[n]
+       │
+       └── Card Body
+           └── clsx(overflow-hidden transition-[max-height] duration-300,
+                    sensesCollapsed[n] ? max-h-0 : max-h-[2000px])
+               └── [all existing sense fields — remain mounted, always registered with RHF]
+```
+
+### Why CSS-only collapse (not unmount)
+
+React-hook-form registers fields at mount time. Unmounting a collapsed Sense card drops its fields from the form payload and skips validation — violating the constraint that hidden fields must still fail validation. `max-h-0 overflow-hidden` hides the card visually while keeping all fields mounted and registered.
+
+---
+
+## Tech Stack
+
+No new packages required. All tools (`useState`, `useEffect`, `useWatch`, `useFieldArray`, `formState.errors`, `clsx`, `ChevronDown`/`ChevronUp` from `lucide-react`, Tailwind `transition-[max-height]`) are already in the stack and used in `EditWordModal.tsx` by TASK-1.
+
+---
+
+## Implementation Details
+
+### Modules / Files
+
+| File                                        | Action | Description                                                                        |
+| ------------------------------------------- | ------ | ---------------------------------------------------------------------------------- |
+| `frontend/src/components/EditWordModal.tsx` | Modify | Add `sensesCollapsed` state, `useEffect` sync, per-sense toggle, collapsed headers |
+
+---
+
+### Key Functions
+
+```typescript
+// State initialisation — parallel boolean array, one entry per sense
+const [sensesCollapsed, setSensesCollapsed] = useState<boolean[]>([]);
+```
+
+```typescript
+// Sync sensesCollapsed length with the useFieldArray fields array.
+// Appends false for new entries; truncates on remove.
+// Re-enrich calls reset(), which repopulates fields from zero — useEffect fires,
+// resetting the array to all-false so the user sees every newly populated Sense expanded.
+useEffect(() => {
+  setSensesCollapsed(prev => {
+    if (fields.length > prev.length) {
+      return [...prev, ...Array(fields.length - prev.length).fill(false)];
+    }
+    return prev.slice(0, fields.length);
+  });
+}, [fields.length]);
+```
+
+```typescript
+// Toggle a single Sense card at index n, leaving all other entries unchanged.
+const toggleSenseCollapsed = (index: number): void => {
+  setSensesCollapsed(prev =>
+    prev.map((collapsed, i) => (i === index ? !collapsed : collapsed))
+  );
+};
+```
+
+```tsx
+// Collapsed card header JSX pattern — inside fields.map((field, n) => ...)
+const meaningPreview = watch(`senses.${n}.meaning_summary`) || 'No summary yet';
+const hasSenseError = !!formState.errors.senses?.[n];
+
+// Header row (always visible)
+<div
+  className="flex items-center cursor-pointer select-none gap-2 py-2"
+  onClick={() => toggleSenseCollapsed(n)}
+>
+  {sensesCollapsed[n] ? <ChevronDown size={16} /> : <ChevronUp size={16} />}
+  <span className="font-medium">Sense {n + 1}</span>
+  {sensesCollapsed[n] && (
+    <span className="text-sm text-gray-500 truncate">{meaningPreview}</span>
+  )}
+  {hasSenseError && sensesCollapsed[n] && (
+    <span className="ml-auto h-2 w-2 rounded-full bg-red-500" />
+  )}
+</div>
+
+// Card body with CSS-only collapse
+<div
+  className={clsx(
+    'overflow-hidden transition-[max-height] duration-300',
+    sensesCollapsed[n] ? 'max-h-0' : 'max-h-[2000px]'
+  )}
+>
+  {/* all existing sense fields unchanged */}
+</div>
+```
+
+---
+
+### Data Models / Schemas
+
+No new data models or schemas introduced. The implementation relies entirely on existing types:
+
+| Symbol                                    | Source                                    | Role                                              |
+| ----------------------------------------- | ----------------------------------------- | ------------------------------------------------- |
+| `boolean[]`                               | built-in                                  | Per-sense collapse state, indexed parallel to `fields` |
+| `fields` (`useFieldArray`)                | react-hook-form                           | Source of truth for sense count and stable IDs    |
+| `formState.errors.senses?.[n]`            | react-hook-form / `wordSchema.senseSchema` | Drives error badge visibility per card            |
+| `` watch(`senses.${n}.meaning_summary`) `` | react-hook-form `useWatch`                | Real-time summary text in collapsed header        |
+
+---
+
+### Testing Strategy
+
+No automated frontend tests exist in this project. Verify manually:
+
+**Happy path:**
+
+1. Open `EditWordModal` for a word with ≥ 2 Senses.
+2. Click the Sense 1 header — confirm: body collapses, Meaning Summary appears in the header row, Sense 2 card unchanged.
+3. Click again — confirm: body expands, summary text hidden from header.
+
+**State sync:**
+
+1. Click "Add Sense" — confirm: new Sense card appears expanded (`sensesCollapsed[n] === false`).
+2. Remove Sense 2 while Sense 3 is collapsed — confirm: Sense 3 re-indexes to Sense 2, collapse state follows correctly.
+3. Click Re-enrich — confirm: all Sense cards expand (array fully reset to `false`).
+
+**Validation:**
+
+1. Collapse a Sense with a required field empty, then click Save — confirm: red error badge appears on the collapsed header; form submission is blocked.
+2. Expand the errored Sense and fix the field — confirm: badge disappears without re-collapsing.
+
+**Edge cases:**
+
+- Sense with no Meaning Summary yet → collapsed header shows "No summary yet"
+- Single-Sense word → one card; collapse/expand works in isolation
+- Very long Meaning Summary → summary text truncates (`truncate` utility class)
+
+---
+
+### Open Questions / Risks
+
+- [x] **Array out-of-sync on rapid append/remove:** `useEffect` on `fields.length` resets the array on every length change. Verify during manual testing that rapid consecutive Remove clicks do not leave stale entries. **Target:** during implementation session. **Answer:** Validation during user test.
+- [x] **CSS max-height clipping on tall Sense cards:** `max-h-[2000px]` may clip a Sense card with many grammar patterns and example sentences. **Target:** review after implementation; increase bound or switch to `max-h-screen` if clipping is observed. **Answer:** Sense Cards will not be this big.
+- [x] **Error badge after Re-enrich reset:** `reset()` clears `formState.errors`; badges should disappear. Verify no stale error state remains after Re-enrich. **Target:** during manual testing step 6. **Answer:** Validation during user test.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] - 2026-05-10
+
+### Changed
+
+- **Frontend**: `EditWordModal` Sense cards are now independently collapsible — click the section header to toggle expand/collapse. Collapsed header displays the Meaning Summary text (or "No summary yet" when empty) and a red error badge when the card contains a validation error. A `sensesCollapsed: boolean[]` state array, indexed parallel to `useFieldArray` `fields`, tracks per-card state; a `useEffect` keeps it in sync on append, remove, and Re-enrich reset. Fields remain mounted (CSS-only `max-height` toggle) so react-hook-form registration and validation are preserved in both states.
+
 ## [0.3.3] - 2026-05-10
 
 ### Changed

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "backend"
-version = "0.3.3"
+version = "0.3.4"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Simone Porreca", email = "porrecasimone@gmail.com" }]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -59,6 +59,10 @@ A Next.js 16 single-page application that provides the user interface for Vademe
 
 ## Changelog
 
+### 2026-05-10 (v0.3.4)
+
+- Updated `EditWordModal.tsx`: each Sense card is now independently collapsible — click the header to toggle. Collapsed header shows the Meaning Summary (or "No summary yet" when empty) and a red error badge when the Sense has a validation error. Added `sensesCollapsed: boolean[]` state, a `useEffect` that keeps the array in sync with `useFieldArray` `fields` (handles append, remove, and Re-enrich reset), and `toggleSenseCollapsed(index)` handler. Fields remain mounted (CSS-only max-height toggle) so react-hook-form registration and validation are preserved in both states.
+
 ### 2026-05-10 (v0.3.3)
 
 - Updated `EditWordModal.tsx`: Verb Morphology card is now collapsible — click the header to toggle; collapsed header shows a real-time principal-forms summary (Infinitiv · Präteritum · Partizip II, or "—" when empty); red error badge appears on the collapsed header when `principal_forms` or `auxiliary_verb` has a validation error; fields remain mounted (CSS-only collapse) so react-hook-form registration is preserved. Added `verbMorphologyCollapsed` state, `useWatch` for `principal_forms`, and `clsx`-driven `max-h` toggle.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/components/EditWordModal.tsx
+++ b/frontend/src/components/EditWordModal.tsx
@@ -64,6 +64,7 @@ export default function EditWordModal({
   const [isEnriching, setIsEnriching] = useState(false);
   const [enrichError, setEnrichError] = useState<string | null>(null);
   const [verbMorphologyCollapsed, setVerbMorphologyCollapsed] = useState(false);
+  const [sensesCollapsed, setSensesCollapsed] = useState<boolean[]>([]);
 
   const {
     register,
@@ -88,6 +89,17 @@ export default function EditWordModal({
     reset(buildDefaultValues(word));
   }, [word, reset]);
 
+  // Keep sensesCollapsed parallel to senseFields — push false for new entries, truncate on remove.
+  // Re-enrich calls reset() which repopulates senseFields from zero, expanding all cards.
+  useEffect(() => {
+    setSensesCollapsed((prev) => {
+      if (senseFields.length > prev.length) {
+        return [...prev, ...Array(senseFields.length - prev.length).fill(false)];
+      }
+      return prev.slice(0, senseFields.length);
+    });
+  }, [senseFields.length]);
+
   const watchedSenses = watch("senses") ?? [];
   const watchedCategory = watch("category");
 
@@ -100,6 +112,12 @@ export default function EditWordModal({
 
   // Guard comes after all hooks
   if (!isOpen) return null;
+
+  const toggleSenseCollapsed = (index: number): void => {
+    setSensesCollapsed((prev) =>
+      prev.map((collapsed, i) => (i === index ? !collapsed : collapsed)),
+    );
+  };
 
   const handleDelete = async () => {
     if (!confirm(`Are you sure you want to delete "${word.word}"?`)) return;
@@ -313,12 +331,35 @@ export default function EditWordModal({
               {senseFields.map((field, sIdx) => (
                 <div
                   key={field.id}
-                  className="border border-forest-200 dark:border-forest-600 rounded-lg p-3 space-y-3"
+                  className="border border-forest-200 dark:border-forest-600 rounded-lg p-3"
                 >
-                  <div className="flex items-center justify-between">
-                    <p className="text-xs font-semibold text-forest-600 dark:text-forest-300 uppercase tracking-wide">
-                      Sense {sIdx + 1}
-                    </p>
+                  {/* Card Header */}
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => toggleSenseCollapsed(sIdx)}
+                      className="flex flex-1 items-center gap-2"
+                    >
+                      {sensesCollapsed[sIdx] ? (
+                        <ChevronDown className="w-3 h-3 text-forest-600 dark:text-forest-300" />
+                      ) : (
+                        <ChevronUp className="w-3 h-3 text-forest-600 dark:text-forest-300" />
+                      )}
+                      <span className="text-xs font-semibold text-forest-600 dark:text-forest-300 uppercase tracking-wide">
+                        Sense {sIdx + 1}
+                      </span>
+                      {sensesCollapsed[sIdx] && (
+                        <span className="text-xs text-forest-500 dark:text-forest-400 truncate">
+                          {watchedSenses[sIdx]?.meaning_summary || "No summary yet"}
+                        </span>
+                      )}
+                      {!!errors.senses?.[sIdx] && sensesCollapsed[sIdx] && (
+                        <span
+                          className="ml-auto h-2 w-2 rounded-full bg-red-500"
+                          aria-label="Contains errors"
+                        />
+                      )}
+                    </button>
                     <button
                       type="button"
                       onClick={() => remove(sIdx)}
@@ -329,90 +370,100 @@ export default function EditWordModal({
                     </button>
                   </div>
 
-                  {/* Meaning Summary */}
-                  <div>
-                    <label className={labelClass}>Meaning Summary</label>
-                    <input
-                      {...register(`senses.${sIdx}.meaning_summary`)}
-                      className={inputClass}
-                    />
-                    {errors.senses?.[sIdx]?.meaning_summary && (
-                      <p className="text-red-500 text-xs">
-                        {errors.senses[sIdx].meaning_summary?.message}
-                      </p>
+                  {/* Card Body */}
+                  <div
+                    className={clsx(
+                      "overflow-hidden transition-[max-height] duration-300",
+                      sensesCollapsed[sIdx] ? "max-h-0" : "max-h-500",
                     )}
-                  </div>
+                  >
+                    <div className="space-y-3 pt-3">
+                      {/* Meaning Summary */}
+                      <div>
+                        <label className={labelClass}>Meaning Summary</label>
+                        <input
+                          {...register(`senses.${sIdx}.meaning_summary`)}
+                          className={inputClass}
+                        />
+                        {errors.senses?.[sIdx]?.meaning_summary && (
+                          <p className="text-red-500 text-xs">
+                            {errors.senses[sIdx].meaning_summary?.message}
+                          </p>
+                        )}
+                      </div>
 
-                  {/* Register */}
-                  <div>
-                    <label className={labelClass}>Register</label>
-                    <select
-                      {...register(`senses.${sIdx}.register`)}
-                      className={inputClass}
-                    >
-                      <option value="Neutral">Neutral</option>
-                      <option value="Formal">Formal</option>
-                      <option value="Colloquial">Colloquial</option>
-                      <option value="Technical">Technical</option>
-                    </select>
-                  </div>
+                      {/* Register */}
+                      <div>
+                        <label className={labelClass}>Register</label>
+                        <select
+                          {...register(`senses.${sIdx}.register`)}
+                          className={inputClass}
+                        >
+                          <option value="Neutral">Neutral</option>
+                          <option value="Formal">Formal</option>
+                          <option value="Colloquial">Colloquial</option>
+                          <option value="Technical">Technical</option>
+                        </select>
+                      </div>
 
-                  {/* Grammar Patterns */}
-                  <div>
-                    <p className="text-xs font-medium text-forest-600 dark:text-forest-300 mb-1">
-                      Grammar Patterns
-                    </p>
-                    {(watchedSenses[sIdx]?.grammar_patterns ?? []).map(
-                      (_, gpIdx) => (
-                        <div key={gpIdx} className="flex gap-2 mt-1">
-                          <input
-                            {...register(
-                              `senses.${sIdx}.grammar_patterns.${gpIdx}.preposition`,
-                            )}
-                            placeholder="Preposition (optional)"
-                            className={inputClass}
-                          />
-                          <select
-                            {...register(
-                              `senses.${sIdx}.grammar_patterns.${gpIdx}.case`,
-                            )}
-                            className={inputClass}
-                          >
-                            <option value="Akkusativ">Akkusativ</option>
-                            <option value="Dativ">Dativ</option>
-                            <option value="Nominativ">Nominativ</option>
-                            <option value="Genitiv">Genitiv</option>
-                          </select>
-                        </div>
-                      ),
-                    )}
-                  </div>
+                      {/* Grammar Patterns */}
+                      <div>
+                        <p className="text-xs font-medium text-forest-600 dark:text-forest-300 mb-1">
+                          Grammar Patterns
+                        </p>
+                        {(watchedSenses[sIdx]?.grammar_patterns ?? []).map(
+                          (_, gpIdx) => (
+                            <div key={gpIdx} className="flex gap-2 mt-1">
+                              <input
+                                {...register(
+                                  `senses.${sIdx}.grammar_patterns.${gpIdx}.preposition`,
+                                )}
+                                placeholder="Preposition (optional)"
+                                className={inputClass}
+                              />
+                              <select
+                                {...register(
+                                  `senses.${sIdx}.grammar_patterns.${gpIdx}.case`,
+                                )}
+                                className={inputClass}
+                              >
+                                <option value="Akkusativ">Akkusativ</option>
+                                <option value="Dativ">Dativ</option>
+                                <option value="Nominativ">Nominativ</option>
+                                <option value="Genitiv">Genitiv</option>
+                              </select>
+                            </div>
+                          ),
+                        )}
+                      </div>
 
-                  {/* Example Sentences */}
-                  <div>
-                    <p className="text-xs font-medium text-forest-600 dark:text-forest-300 mb-1">
-                      Example Sentences
-                    </p>
-                    {(watchedSenses[sIdx]?.example_sentences ?? []).map(
-                      (_, exIdx) => (
-                        <div key={exIdx} className="space-y-1 mt-1">
-                          <input
-                            {...register(
-                              `senses.${sIdx}.example_sentences.${exIdx}.german`,
-                            )}
-                            placeholder="German sentence"
-                            className={inputClass}
-                          />
-                          <input
-                            {...register(
-                              `senses.${sIdx}.example_sentences.${exIdx}.english`,
-                            )}
-                            placeholder="English translation"
-                            className={inputClass}
-                          />
-                        </div>
-                      ),
-                    )}
+                      {/* Example Sentences */}
+                      <div>
+                        <p className="text-xs font-medium text-forest-600 dark:text-forest-300 mb-1">
+                          Example Sentences
+                        </p>
+                        {(watchedSenses[sIdx]?.example_sentences ?? []).map(
+                          (_, exIdx) => (
+                            <div key={exIdx} className="space-y-1 mt-1">
+                              <input
+                                {...register(
+                                  `senses.${sIdx}.example_sentences.${exIdx}.german`,
+                                )}
+                                placeholder="German sentence"
+                                className={inputClass}
+                              />
+                              <input
+                                {...register(
+                                  `senses.${sIdx}.example_sentences.${exIdx}.english`,
+                                )}
+                                placeholder="English translation"
+                                className={inputClass}
+                              />
+                            </div>
+                          ),
+                        )}
+                      </div>
+                    </div>
                   </div>
                 </div>
               ))}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vademecum-germanicum"
-version = "0.3.3"
+version = "0.3.4"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Description

The PR resolves the issue #48 by adding Collapsable Sense card feature.

## Changelog

### Changed

- **Frontend**: `EditWordModal` Sense cards are now independently collapsible — click the section header to toggle expand/collapse. Collapsed header displays the Meaning Summary text (or "No summary yet" when empty) and a red error badge when the card contains a validation error. A `sensesCollapsed: boolean[]` state array, indexed parallel to `useFieldArray` `fields`, tracks per-card state; a `useEffect` keeps it in sync on append, remove, and Re-enrich reset. Fields remain mounted (CSS-only `max-height` toggle) so react-hook-form registration and validation are preserved in both states.

## Checklist

### Mandatory

- [x] The title of the Pull Request starts with the JIRA ticket number (if provided)
- [x] The title of the Pull Request must reflect the corresponding issue title
- [x] It has to have a `Description` section, specifying which is the `#issue` it's resolving and how
- [x] It has to have a `Changelog` section, reporting what has been changed in the corresponding issue
- [x] The project version must have been updated

### Optional

- [x] Update the Wiki
- [x] Update the `README.md`
- [x] Update the `CHANGELOG.md`
