### PR TITLE
Feat/49 Global collapse all button

### DIFF
--- a/.claude/planning/4-collapsable-cards/47-collapsible-verb-morphology-card.md
+++ b/.claude/planning/4-collapsable-cards/47-collapsible-verb-morphology-card.md
@@ -1,0 +1,202 @@
+# #47: Collapsible Verb Morphology Card
+
+**GitHub Issue:** [#47 — Collapsible Verb Morphology Card](https://github.com/Volscente/vademecum-germanicum/issues/47)
+**GitHub Milestone:** [Milestone: 4-collapsable-cards](https://github.com/Volscente/vademecum-germanicum/milestone/4-collapsable-cards)
+**Notion page:** [4-Collapsable Cards](https://www.notion.so/4-Collapsable-Cards-35c5cc6c0f0780fcaf30f0929b928375)
+
+---
+
+## Technical Scope
+
+**In scope:**
+
+- `frontend/src/components/EditWordModal.tsx` — Add `verbMorphologyCollapsed` boolean state, a clickable card header with `ChevronDown`/`ChevronUp` icon, CSS max-height collapse on the card body (fields stay mounted), conditional render guard hiding the whole card when `category !== 'verb'`, real-time principal-forms summary via `useWatch`, and an error badge keyed to `formState.errors.principal_forms` / `formState.errors.auxiliary_verb`
+
+**Out of scope:**
+
+- `frontend/src/lib/wordSchema.ts` — no schema changes
+- `frontend/src/lib/api.ts` — no API changes
+- `frontend/src/types/word.ts` — no type changes
+- Collapsible Sense cards (TASK-2)
+- Global "Collapse All" button (TASK-3)
+
+---
+
+## Architecture
+
+```txt
+EditWordModal.tsx (single integration point)
+    │
+    ├─ Local state: verbMorphologyCollapsed: boolean  (default: false)
+    │
+    ├─ watch('category') === 'verb'?
+    │       │  NO  ──► card not rendered at all
+    │       │
+    │       │  YES
+    │       ▼
+    │   [Card Header — clickable row]
+    │       ├─ ChevronUp / ChevronDown  (lucide-react, already imported)
+    │       ├─ "Verb Morphology" title
+    │       ├─ Summary text  ◄── useWatch(['principal_forms'])
+    │       │                    "Infinitiv · Präteritum · Partizip II"
+    │       │                    fallback "—" when any value is empty
+    │       └─ Error badge (red dot)
+    │                ▲── rendered when:
+    │                    !!formState.errors.principal_forms ||
+    │                    !!formState.errors.auxiliary_verb
+    │
+    └─ [Card Body]
+            └─ clsx toggle on verbMorphologyCollapsed
+                    true  → 'max-h-0 overflow-hidden'   (hidden, fields MOUNTED)
+                    false → 'max-h-[2000px]'             (visible)
+               + 'transition-[max-height] duration-300'  (smooth animation)
+               Fields remain registered with RHF in both states.
+```
+
+### Why CSS-only collapse instead of conditional unmount
+
+Collapsing via `max-h-0 overflow-hidden` keeps the fields mounted and registered with react-hook-form. Unmounting would drop their registration, excluding them from validation and the submitted payload — violating the stated constraint that hidden fields must still trigger validation errors.
+
+---
+
+## Tech Stack
+
+No new packages required.
+
+| Package | Already in stack | Role in this task |
+| --- | --- | --- |
+| `react-hook-form` | Yes | `useWatch` for real-time summary; `formState.errors` for error badge |
+| `lucide-react` | Yes | `ChevronDown`, `ChevronUp` icons for toggle affordance |
+| `tailwindcss` v4 | Yes | `max-h-0`, `max-h-[2000px]`, `overflow-hidden`, `transition-[max-height]` |
+| `clsx` / `tailwind-merge` | Yes | Conditional class merging on the card body |
+
+---
+
+## Implementation Details
+
+### Modules / Files
+
+| File | Action | Description |
+| --- | --- | --- |
+| `frontend/src/components/EditWordModal.tsx` | Modify | All changes for this task live here; no other files change |
+
+---
+
+### Key Logic Blocks
+
+**1 — State declaration** (add alongside existing `useState` calls in `EditWordModal`):
+
+```tsx
+const [verbMorphologyCollapsed, setVerbMorphologyCollapsed] = useState(false);
+```
+
+**2 — Principal-forms summary** (add alongside existing `watch` / `useWatch` calls):
+
+```tsx
+const watchedPrincipalForms = useWatch({ control, name: 'principal_forms' });
+// principal_forms is z.array(z.string()) — a flat string[]
+// [0] = Infinitiv, [1] = Präteritum, [2] = Partizip II (order fixed by the 3-input grid in the form)
+
+const verbMorphologySummary =
+  watchedPrincipalForms?.[0] && watchedPrincipalForms?.[1] && watchedPrincipalForms?.[2]
+    ? `${watchedPrincipalForms[0]} · ${watchedPrincipalForms[1]} · ${watchedPrincipalForms[2]}`
+    : '—';
+```
+
+**3 — Error badge condition:**
+
+```tsx
+const verbMorphologyHasError =
+  !!formState.errors.principal_forms || !!formState.errors.auxiliary_verb;
+```
+
+**4 — Conditional render guard + card header + card body** (wraps the existing Verb Morphology JSX block):
+
+```tsx
+{(watchedCategory === 'verb' || word.auxiliary_verb) && (
+  <div className="border border-forest-200 dark:border-forest-600 rounded-lg p-3 space-y-3">
+    {/* Card Header */}
+    <button
+      type="button"
+      onClick={() => setVerbMorphologyCollapsed((prev) => !prev)}
+      className="flex w-full items-center gap-2"
+    >
+      {verbMorphologyCollapsed
+        ? <ChevronDown className="w-3 h-3 text-forest-600 dark:text-forest-300" />
+        : <ChevronUp className="w-3 h-3 text-forest-600 dark:text-forest-300" />
+      }
+      <span className="text-xs font-semibold text-forest-600 dark:text-forest-300 uppercase tracking-wide">
+        Verb Morphology
+      </span>
+      {verbMorphologyCollapsed && (
+        <span className="ml-2 text-xs text-forest-500 dark:text-forest-400">{verbMorphologySummary}</span>
+      )}
+      {verbMorphologyHasError && (
+        <span className="ml-auto h-2 w-2 rounded-full bg-red-500" aria-label="Contains errors" />
+      )}
+    </button>
+
+    {/* Card Body — fields stay mounted, only visual height changes */}
+    <div
+      className={clsx(
+        'overflow-hidden transition-[max-height] duration-300',
+        verbMorphologyCollapsed ? 'max-h-0' : 'max-h-500',
+      )}
+    >
+      {/* existing auxiliary_verb and principal_forms fields unchanged */}
+    </div>
+  </div>
+)}
+```
+
+> **Note on render condition:** The current code uses `(watchedCategory === "verb" || word.auxiliary_verb)` — this is preserved as-is. The RFC-stated guard `category === 'verb'` is satisfied by the first branch; the `|| word.auxiliary_verb` fallback keeps existing verb words visible even if the user switches category mid-edit.
+
+---
+
+### Data Models / Schemas
+
+No new models. The existing types that this task reads:
+
+```ts
+// From frontend/src/lib/wordSchema.ts (verified)
+principal_forms: z.array(z.string()).optional()
+// → WordFormValues['principal_forms']: string[] | undefined
+// Index mapping (fixed by the 3-column grid in the form):
+//   [0] = Infinitiv   [1] = Präteritum   [2] = Partizip II
+
+// From frontend/src/types/word.ts
+principal_forms?: string[]   // same flat array shape on the Word interface
+auxiliary_verb?: string
+category: string             // 'verb' | 'noun' | 'adjective' | 'adverb' | 'pronoun'
+```
+
+---
+
+### Testing Strategy
+
+**Manual / visual (golden path):**
+
+1. Open `EditWordModal` for a **verb** word → Verb Morphology card is visible and expanded by default.
+2. Click the card header → card collapses; summary line shows the three principal forms (or `"—"` if empty).
+3. Click again → card expands; fields are intact and their values unchanged.
+4. With the card collapsed, edit a principal-forms field in another tab / via devtools → summary text updates in real-time when expanded again.
+
+**Manual / visual (edge cases):**
+
+| Scenario | Expected behaviour |
+| --- | --- |
+| Word `category !== 'verb'` (noun, adjective, etc.) | Verb Morphology card is not rendered at all |
+| Card collapsed, `principal_forms` fields empty | Collapsed header shows `"—"` placeholder |
+| Card collapsed, `principal_forms` partially filled | Collapsed header shows `"—"` (all three must be present) |
+| Form submitted with a required verb field empty while card is collapsed | RHF validation fires; red error badge appears on collapsed header |
+| Word `category` changes from `verb` to `noun` mid-edit | Card disappears; state `verbMorphologyCollapsed` resets irrelevant (card not rendered) |
+
+**No automated tests required for this task** — all behavior is ephemeral UI state in a single component. RHF validation correctness is already covered by existing schema tests in `wordSchema.ts`.
+
+---
+
+### Open Questions / Risks
+
+- [x] **Exact `principal_forms` field path in `wordSchema`:** Confirmed — `principal_forms` is `z.array(z.string())`, a flat `string[]`. Index order `[0, 1, 2]` maps to Infinitiv, Präteritum, Partizip II (fixed by the existing 3-column input grid). `useWatch` call uses array indexing, not object property access. **Resolved.**
+- [x] **CSS `max-h-[2000px]` clipping:** The card contains only two fields (`auxiliary_verb` + `principal_forms` 3-column grid) — clipping is not a concern. Using canonical Tailwind v4 class `max-h-500` (equivalent to 2000px via `--spacing × 500`). **Resolved — card implemented as designed.**
+- [x] **Card header styling consistency:** Confirmed from existing `EditWordModal.tsx` code. Card wrapper: `border border-forest-200 dark:border-forest-600 rounded-lg p-3 space-y-3`. Header label: `text-xs font-semibold text-forest-600 dark:text-forest-300 uppercase tracking-wide`. Icon size: `w-3 h-3`. Summary text: `text-xs text-forest-500 dark:text-forest-400`. No new design tokens introduced. **Resolved.**

--- a/.claude/planning/4-collapsable-cards/48-collapsible-sense-cards.md
+++ b/.claude/planning/4-collapsable-cards/48-collapsible-sense-cards.md
@@ -1,0 +1,183 @@
+# #48: Collapsible Sense Cards
+
+**GitHub Issue:** [#48 — Collapsible Sense Cards](https://github.com/Volscente/vademecum-germanicum/issues/48)
+**GitHub Milestone:** [4-collapsable-cards](https://github.com/Volscente/vademecum-germanicum/milestone/4-collapsable-cards)
+**Notion page:** [4-Collapsable Cards](https://www.notion.so/4-Collapsable-Cards-35c5cc6c0f0780fcaf30f0929b928375)
+
+---
+
+## Technical Scope
+
+**In scope:**
+
+- `frontend/src/components/EditWordModal.tsx` — add `sensesCollapsed: boolean[]` local state; `useEffect` to sync array length with `fields.length` from `useFieldArray`; per-sense toggle handler; collapsed card header (ChevronDown/ChevronUp icon, Meaning Summary text, error badge); CSS max-height collapse on each Sense card body
+
+**Out of scope:**
+
+- `frontend/src/lib/wordSchema.ts` — no schema changes required
+- `frontend/src/lib/api.ts` — no API changes required
+- `frontend/src/types/word.ts` — no type changes required
+- `frontend/src/components/AddWordModal.tsx` — not touched
+- Global "Collapse All" button (TASK-3 / Issue #49)
+
+---
+
+## Architecture
+
+```txt
+EditWordModal.tsx
+│
+├── verbMorphologyCollapsed: boolean          ← already in place (TASK-1 / v0.3.3)
+├── sensesCollapsed: boolean[]               ← NEW
+│   └── useEffect([fields.length])           ← grow/truncate on append / remove / Re-enrich reset
+│
+├── fields (useFieldArray on "senses")
+│   └── fields[n] — one entry per Sense
+│
+└── JSX: fields.map((field, n) => ...)
+       │
+       ├── Card Header (always rendered)
+       │   ├── ChevronDown / ChevronUp icon  ← onClick: toggleSenseCollapsed(n)
+       │   ├── "Sense {n+1}" title
+       │   ├── watch(`senses.${n}.meaning_summary`) or "No summary yet"  ← shown when collapsed
+       │   └── red dot badge if !!errors.senses?.[n] && sensesCollapsed[n]
+       │
+       └── Card Body
+           └── clsx(overflow-hidden transition-[max-height] duration-300,
+                    sensesCollapsed[n] ? max-h-0 : max-h-[2000px])
+               └── [all existing sense fields — remain mounted, always registered with RHF]
+```
+
+### Why CSS-only collapse (not unmount)
+
+React-hook-form registers fields at mount time. Unmounting a collapsed Sense card drops its fields from the form payload and skips validation — violating the constraint that hidden fields must still fail validation. `max-h-0 overflow-hidden` hides the card visually while keeping all fields mounted and registered.
+
+---
+
+## Tech Stack
+
+No new packages required. All tools (`useState`, `useEffect`, `useWatch`, `useFieldArray`, `formState.errors`, `clsx`, `ChevronDown`/`ChevronUp` from `lucide-react`, Tailwind `transition-[max-height]`) are already in the stack and used in `EditWordModal.tsx` by TASK-1.
+
+---
+
+## Implementation Details
+
+### Modules / Files
+
+| File                                        | Action | Description                                                                        |
+| ------------------------------------------- | ------ | ---------------------------------------------------------------------------------- |
+| `frontend/src/components/EditWordModal.tsx` | Modify | Add `sensesCollapsed` state, `useEffect` sync, per-sense toggle, collapsed headers |
+
+---
+
+### Key Functions
+
+```typescript
+// State initialisation — parallel boolean array, one entry per sense
+const [sensesCollapsed, setSensesCollapsed] = useState<boolean[]>([]);
+```
+
+```typescript
+// Sync sensesCollapsed length with the useFieldArray fields array.
+// Appends false for new entries; truncates on remove.
+// Re-enrich calls reset(), which repopulates fields from zero — useEffect fires,
+// resetting the array to all-false so the user sees every newly populated Sense expanded.
+useEffect(() => {
+  setSensesCollapsed(prev => {
+    if (fields.length > prev.length) {
+      return [...prev, ...Array(fields.length - prev.length).fill(false)];
+    }
+    return prev.slice(0, fields.length);
+  });
+}, [fields.length]);
+```
+
+```typescript
+// Toggle a single Sense card at index n, leaving all other entries unchanged.
+const toggleSenseCollapsed = (index: number): void => {
+  setSensesCollapsed(prev =>
+    prev.map((collapsed, i) => (i === index ? !collapsed : collapsed))
+  );
+};
+```
+
+```tsx
+// Collapsed card header JSX pattern — inside fields.map((field, n) => ...)
+const meaningPreview = watch(`senses.${n}.meaning_summary`) || 'No summary yet';
+const hasSenseError = !!formState.errors.senses?.[n];
+
+// Header row (always visible)
+<div
+  className="flex items-center cursor-pointer select-none gap-2 py-2"
+  onClick={() => toggleSenseCollapsed(n)}
+>
+  {sensesCollapsed[n] ? <ChevronDown size={16} /> : <ChevronUp size={16} />}
+  <span className="font-medium">Sense {n + 1}</span>
+  {sensesCollapsed[n] && (
+    <span className="text-sm text-gray-500 truncate">{meaningPreview}</span>
+  )}
+  {hasSenseError && sensesCollapsed[n] && (
+    <span className="ml-auto h-2 w-2 rounded-full bg-red-500" />
+  )}
+</div>
+
+// Card body with CSS-only collapse
+<div
+  className={clsx(
+    'overflow-hidden transition-[max-height] duration-300',
+    sensesCollapsed[n] ? 'max-h-0' : 'max-h-[2000px]'
+  )}
+>
+  {/* all existing sense fields unchanged */}
+</div>
+```
+
+---
+
+### Data Models / Schemas
+
+No new data models or schemas introduced. The implementation relies entirely on existing types:
+
+| Symbol                                    | Source                                    | Role                                              |
+| ----------------------------------------- | ----------------------------------------- | ------------------------------------------------- |
+| `boolean[]`                               | built-in                                  | Per-sense collapse state, indexed parallel to `fields` |
+| `fields` (`useFieldArray`)                | react-hook-form                           | Source of truth for sense count and stable IDs    |
+| `formState.errors.senses?.[n]`            | react-hook-form / `wordSchema.senseSchema` | Drives error badge visibility per card            |
+| `` watch(`senses.${n}.meaning_summary`) `` | react-hook-form `useWatch`                | Real-time summary text in collapsed header        |
+
+---
+
+### Testing Strategy
+
+No automated frontend tests exist in this project. Verify manually:
+
+**Happy path:**
+
+1. Open `EditWordModal` for a word with ≥ 2 Senses.
+2. Click the Sense 1 header — confirm: body collapses, Meaning Summary appears in the header row, Sense 2 card unchanged.
+3. Click again — confirm: body expands, summary text hidden from header.
+
+**State sync:**
+
+1. Click "Add Sense" — confirm: new Sense card appears expanded (`sensesCollapsed[n] === false`).
+2. Remove Sense 2 while Sense 3 is collapsed — confirm: Sense 3 re-indexes to Sense 2, collapse state follows correctly.
+3. Click Re-enrich — confirm: all Sense cards expand (array fully reset to `false`).
+
+**Validation:**
+
+1. Collapse a Sense with a required field empty, then click Save — confirm: red error badge appears on the collapsed header; form submission is blocked.
+2. Expand the errored Sense and fix the field — confirm: badge disappears without re-collapsing.
+
+**Edge cases:**
+
+- Sense with no Meaning Summary yet → collapsed header shows "No summary yet"
+- Single-Sense word → one card; collapse/expand works in isolation
+- Very long Meaning Summary → summary text truncates (`truncate` utility class)
+
+---
+
+### Open Questions / Risks
+
+- [x] **Array out-of-sync on rapid append/remove:** `useEffect` on `fields.length` resets the array on every length change. Verify during manual testing that rapid consecutive Remove clicks do not leave stale entries. **Target:** during implementation session. **Answer:** Validation during user test.
+- [x] **CSS max-height clipping on tall Sense cards:** `max-h-[2000px]` may clip a Sense card with many grammar patterns and example sentences. **Target:** review after implementation; increase bound or switch to `max-h-screen` if clipping is observed. **Answer:** Sense Cards will not be this big.
+- [x] **Error badge after Re-enrich reset:** `reset()` clears `formState.errors`; badges should disappear. Verify no stale error state remains after Re-enrich. **Target:** during manual testing step 6. **Answer:** Validation during user test.

--- a/.claude/planning/4-collapsable-cards/49-global-collapse-all-button.md
+++ b/.claude/planning/4-collapsable-cards/49-global-collapse-all-button.md
@@ -1,0 +1,94 @@
+# #49: Global "Collapse All" Button
+
+**GitHub Issue:** [#49 — Global "Collapse All" Button](https://github.com/Volscente/vademecum-germanicum/issues/49)
+**GitHub Milestone:** [4-collapsable-cards](https://github.com/Volscente/vademecum-germanicum/milestone/4-collapsable-cards)
+**Notion page:** [4-Collapsable Cards](https://www.notion.so/4-Collapsable-Cards-35c5cc6c0f0780fcaf30f0929b928375)
+
+---
+
+## Technical Scope
+
+**In scope:**
+
+- `frontend/src/components/EditWordModal.tsx` — Add a "Collapse All" button to the modal header row; wire a click handler that bulk-sets `verbMorphologyCollapsed = true` and every `sensesCollapsed` entry to `true`
+
+**Out of scope:**
+
+- Any changes to `wordSchema.ts`, `api.ts`, `types/word.ts`, or any other component
+- An "Expand All" button (not requested)
+- Persisting collapse state across modal open/close cycles
+
+---
+
+## Architecture
+
+```txt
+EditWordModal — modal header row
+  ├── [Re-enrich]  [Delete]  [×]          (existing controls)
+  └── [Collapse All]                       (new button)
+            │
+            ▼ onClick: handleCollapseAll()
+            ├── setVerbMorphologyCollapsed(true)   ── collapses Verb Morphology card
+            └── setSensesCollapsed(prev =>          ── collapses every Sense card
+                  prev.map(() => true))
+```
+
+### Why bulk-set instead of a shared "all collapsed" flag
+
+`verbMorphologyCollapsed` and `sensesCollapsed` are independent state slices introduced in TASK-1 and TASK-2. Merging them into a shared flag would require refactoring both prior tasks. Since "Collapse All" is a one-way bulk write (not a toggle), reading and overwriting each slice directly is the simplest approach with no structural change.
+
+---
+
+## Tech Stack
+
+No new packages required.
+
+---
+
+## Implementation Details
+
+### Modules / Files
+
+| File                                          | Action | Description                                                      |
+| --------------------------------------------- | ------ | ---------------------------------------------------------------- |
+| `frontend/src/components/EditWordModal.tsx`   | Edit   | Add `handleCollapseAll` handler and "Collapse All" button in the modal header |
+
+---
+
+### Key Functions
+
+```typescript
+const handleCollapseAll = () => {
+  setVerbMorphologyCollapsed(true);
+  setSensesCollapsed((prev) => prev.map(() => true));
+};
+```
+
+Both state setters (`setVerbMorphologyCollapsed`, `setSensesCollapsed`) are already declared in scope from TASK-1 and TASK-2. No new state variables are needed.
+
+**Button placement** — inside the modal header row alongside the existing Re-enrich, Delete, and Close controls. Use existing Tailwind utility classes (e.g., `text-sm text-forest-700 hover:text-forest-900 dark:text-forest-300`) to match adjacent button styling.
+
+---
+
+### Testing Strategy
+
+**Manual (golden path):**
+
+1. Open `EditWordModal` for a verb word with at least two Senses.
+2. Verify all cards start expanded.
+3. Click "Collapse All".
+4. Verify the Verb Morphology card collapses to its summary header.
+5. Verify every Sense card collapses to its summary header.
+
+**Edge cases:**
+
+- Word with no Senses (empty `fields` array) → `sensesCollapsed` is `[]`; clicking "Collapse All" is a no-op for senses, Verb Morphology still collapses correctly.
+- Non-verb word (`category !== 'verb'`) → Verb Morphology card is not rendered; "Collapse All" only affects `sensesCollapsed` entries; no error thrown.
+- Cards already individually collapsed before clicking "Collapse All" → handler is idempotent; no visual change, no state corruption.
+- Click "Collapse All", then individually expand one card → that card expands independently; state for other cards is unaffected.
+
+---
+
+### Open Questions / Risks
+
+- [x] **Button label and placement:** "Collapse All" as text button in the header row is assumed; confirm placement doesn't crowd the existing Re-enrich/Delete/Close controls on small viewports. **Target:** during implementation. **Aswer:** Place the "Collapse All" button just above the "Verb Morphology" card.

--- a/.claude/planning/4-collapsable-cards/planning.md
+++ b/.claude/planning/4-collapsable-cards/planning.md
@@ -22,7 +22,7 @@ TASK-1 ──► TASK-2 ──► TASK-3
 
 ## TASK-1 — Collapsible Verb Morphology Card
 
-**GitHub Issue:** #{issue}
+**GitHub Issue:** [Collapsible Verb Morphology Card](https://github.com/Volscente/vademecum-germanicum/issues/47)
 **Effort estimate:** 0.5 FTE-days
 
 ### Scope
@@ -53,7 +53,7 @@ No changes to `wordSchema.ts`, `api.ts`, or `types/word.ts`.
 
 ## TASK-2 — Collapsible Sense Cards
 
-**GitHub Issue:** #{issue}
+**GitHub Issue:** [Collapsible Sense Cards](https://github.com/Volscente/vademecum-germanicum/issues/48)
 **Effort estimate:** 0.5 FTE-days
 
 ### Scope
@@ -86,7 +86,7 @@ Card body collapse: same CSS pattern as TASK-1, indexed on `sensesCollapsed[n]`.
 
 ## TASK-3 — Global "Collapse All" Button
 
-**GitHub Issue:** #{issue}
+**GitHub Issue:** [Global "Collapse All" Button](https://github.com/Volscente/vademecum-germanicum/issues/49)
 **Effort estimate:** 0.25 FTE-days
 
 ### Scope

--- a/.claude/planning/4-collapsable-cards/planning.md
+++ b/.claude/planning/4-collapsable-cards/planning.md
@@ -1,0 +1,172 @@
+# Collapsible UI Components for Word Management — High-Level Planning
+
+**Project:** Vademecum Germanicum
+**GitHub repo:** [Volscente/vademecum-germanicum](https://github.com/Volscente/vademecum-germanicum)
+**GitHub Milestone:** [Milestone: 4-collapsable-cards](https://github.com/Volscente/vademecum-germanicum/milestone/4-collapsable-cards)
+**Notion page:** [4-Collapsable Cards](https://www.notion.so/4-Collapsable-Cards-35c5cc6c0f0780fcaf30f0929b928375)
+**Total estimated effort:** 1.25 FTE-days (1 FTE = 1 day)
+
+---
+
+## Overview
+
+This initiative adds accordion-style collapse behavior to the `EditWordModal` component, which currently forces the user to scroll through all word data (verb morphology and multiple Senses) in one uninterrupted form. Each card receives an independent toggle; collapsed headers display a real-time summary derived from current form state (principal forms for Verb Morphology, Meaning Summary for each Sense). All fields remain mounted in the DOM so react-hook-form validation continues to fire for hidden content.
+
+### Dependency Order
+
+```txt
+TASK-1 ──► TASK-2 ──► TASK-3
+```
+
+---
+
+## TASK-1 — Collapsible Verb Morphology Card
+
+**GitHub Issue:** #{issue}
+**Effort estimate:** 0.5 FTE-days
+
+### Scope
+
+Introduce `verbMorphologyCollapsed: boolean` local state in `EditWordModal.tsx` and wrap the Verb Morphology section in a toggleable card header. Add conditional rendering so the entire card is hidden when `watch('category') !== 'verb'`. Implement the collapsed summary header and the error indicator.
+
+### Goal
+
+The Verb Morphology card can be collapsed to a single-line header showing the three principal forms, and disappears entirely for non-verb words. This task establishes the card-header pattern that TASK-2 reuses for Senses.
+
+### Deliverables
+
+- `frontend/src/components/EditWordModal.tsx` — `verbMorphologyCollapsed` state, card header with `ChevronDown`/`ChevronUp` toggle, CSS collapse (`max-h-0 overflow-hidden transition-[max-height]`), conditional render guard (`category === 'verb'`), real-time summary via `useWatch('principal_forms')`, error badge keyed to `formState.errors.principal_forms`
+
+### Technical Overview
+
+State: `const [verbMorphologyCollapsed, setVerbMorphologyCollapsed] = useState(false)`.
+
+Card header row: `ChevronDown`/`ChevronUp` icon (lucide-react, already available) + card title + summary text + optional red error dot. Summary text = `watch('principal_forms')` values joined as `"Infinitiv, Präteritum, Partizip II"`; fallback `"—"` when any value is empty. Error badge: rendered when `!!formState.errors.principal_forms || !!formState.errors.auxiliary_verb`.
+
+Card body: toggled via `clsx('overflow-hidden transition-[max-height] duration-300', verbMorphologyCollapsed ? 'max-h-0' : 'max-h-[2000px]')`. Fields remain mounted so RHF registration is preserved and validation fires even when collapsed.
+
+Conditional render: wrap the entire card in `{watch('category') === 'verb' && (…)}`.
+
+No changes to `wordSchema.ts`, `api.ts`, or `types/word.ts`.
+
+---
+
+## TASK-2 — Collapsible Sense Cards
+
+**GitHub Issue:** #{issue}
+**Effort estimate:** 0.5 FTE-days
+
+### Scope
+
+Introduce `sensesCollapsed: boolean[]` local state in `EditWordModal.tsx`, parallel to the `useFieldArray` `fields` array. Apply the card-header pattern from TASK-1 to each Sense card with independent per-sense toggles. Sync the array with `fields.length` via `useEffect`. Add the error indicator for each Sense card.
+
+### Goal
+
+Each Sense card can be independently collapsed to a single-line header showing its Meaning Summary, and the collapse state stays correct when senses are added, removed, or replaced by Re-enrich.
+
+### Deliverables
+
+- `frontend/src/components/EditWordModal.tsx` — `sensesCollapsed` state, `useEffect` sync with `fields.length`, per-sense card headers with independent toggle, real-time summary via `useWatch` on `senses.N.meaning_summary`, error badges keyed to `formState.errors.senses?.[n]`, CSS collapse on each Sense card body
+
+### Technical Overview
+
+State: `const [sensesCollapsed, setSensesCollapsed] = useState<boolean[]>([])`.
+
+Sync: on every change to `fields.length`, grow the array by pushing `false` for new entries or truncate for removed entries. This handles both append and remove, and Re-enrich's `reset()` call which repopulates `fields` from zero.
+
+Per-sense toggle: update only the entry at index `n`, leaving others unchanged.
+
+Collapsed summary: `watch(`senses.${n}.meaning_summary`)` or `"No summary yet"` fallback.
+
+Error badge: rendered when `!!formState.errors.senses?.[n]`.
+
+Card body collapse: same CSS pattern as TASK-1, indexed on `sensesCollapsed[n]`.
+
+---
+
+## TASK-3 — Global "Collapse All" Button
+
+**GitHub Issue:** #{issue}
+**Effort estimate:** 0.25 FTE-days
+
+### Scope
+
+Add a "Collapse All" button to the modal header row in `EditWordModal.tsx` that sets `verbMorphologyCollapsed = true` and all `sensesCollapsed` entries to `true` in a single click. Requires TASK-1 and TASK-2 state to already be in place.
+
+### Goal
+
+Users can condense the entire modal to a summary view with one action, reducing scroll distance when a word has many Senses.
+
+### Deliverables
+
+- `frontend/src/components/EditWordModal.tsx` — "Collapse All" button in the modal header, click handler that bulk-sets both state slices
+
+### Technical Overview
+
+Handler: set `verbMorphologyCollapsed` to `true` and map all entries of `sensesCollapsed` to `true`. Button placed in the modal header row alongside existing controls (Re-enrich, Delete, Close), styled with existing Tailwind utility classes. No new state, no new dependencies.
+
+---
+
+## GitHub Issues
+
+### Milestone 1 — Collapsible Verb Morphology Card
+
+**Tasks:** TASK-1
+**Effort:** 0.5 FTE-days
+
+#### Scope
+
+Add collapse/expand behavior and a toggle card header to the Verb Morphology section of `EditWordModal`. Add conditional rendering to hide the card entirely for non-verb words.
+
+#### Goal
+
+The Verb Morphology card shows a one-line principal-forms summary when collapsed and disappears for non-verb entries. The card-header pattern is validated and ready to be applied to Senses.
+
+#### Deliverables
+
+- `verbMorphologyCollapsed` state and toggle handler in `EditWordModal.tsx`
+- Card header with ChevronDown/ChevronUp, principal-forms summary text, and error badge
+- CSS max-height collapse on the card body (fields remain mounted)
+- Conditional render guard (`category === 'verb'`)
+
+---
+
+### Milestone 2 — Collapsible Sense Cards
+
+**Tasks:** TASK-2
+**Effort:** 0.5 FTE-days
+
+#### Scope
+
+Apply the card-header pattern from Milestone 1 to every Sense card, with independent per-sense collapse state managed as a `boolean[]` synced to `useFieldArray`.
+
+#### Goal
+
+Each Sense card collapses independently to a one-line Meaning Summary header. The state array stays correct across append, remove, and Re-enrich operations.
+
+#### Deliverables
+
+- `sensesCollapsed: boolean[]` state and per-sense toggle handler in `EditWordModal.tsx`
+- `useEffect` sync with `fields.length` (handles append, remove, Re-enrich reset)
+- Per-sense card headers with Meaning Summary text and error badges
+- CSS max-height collapse on each Sense card body
+
+---
+
+### Milestone 3 — Global "Collapse All" Button
+
+**Tasks:** TASK-3
+**Effort:** 0.25 FTE-days
+
+#### Scope
+
+Add a "Collapse All" button to the modal header that bulk-collapses every collapsible card (Verb Morphology + all Senses) in a single action.
+
+#### Goal
+
+Users can reduce the entire modal to a compact summary view with one click, making the form manageable when a word has multiple Senses.
+
+#### Deliverables
+
+- "Collapse All" button in the `EditWordModal` header row
+- Click handler setting `verbMorphologyCollapsed = true` and all `sensesCollapsed` entries to `true`

--- a/.claude/rfc/4-collapsable-cards/proposal.md
+++ b/.claude/rfc/4-collapsable-cards/proposal.md
@@ -1,0 +1,62 @@
+---
+title: "Collapsible UI Components for Word Management"
+project: "Vademecum Germanicum"
+author: "Simone Porreca"
+deadline: "2026-05-12"
+notion-page: "https://www.notion.so/4-Collapsable-Cards-35c5cc6c0f0780fcaf30f0929b928375"
+github-repo: "https://github.com/Volscente/vademecum-germanicum"
+milestone: "4-collapsable-cards"
+tech-stack:
+  - ""
+scope-in:
+  - "Interactive toggle functionality for 'Verb Morphology' card"
+  - "Independent toggle functionality for each 'Sense X' card"
+  - "Summary view logic for collapsed Verb Morphology (Infinitiv, Präteritum, Partizip II)"
+  - "Summary view logic for collapsed Senses (Meaning Summary)"
+  - "Conditional rendering to hide the Verb Morphology card if no data is present"
+  - "Global 'Collapse All' button for every card" 
+scope-out:
+  - "Drag-and-drop reordering of senses: out of scope"
+milestones:
+  - ""
+context-paths:
+  - "frontend/README.md"
+---
+
+## Problem
+
+The current 'Edit Word' form suffers from significant information overload. The modal is vertically long, requiring extensive scrolling to navigate between the basic word details and the various meanings (Senses). This makes it difficult for users to quickly scan the data or find specific sections without being distracted by secondary grammatical details.
+
+## Approach direction
+
+Introduce an 'Accordion-style' behavior for the major data sections. By default, sections should likely remain expanded or remember their state, but provide a one-click toggle to condense the cards into a single-line summary.
+
+For the 'Verb Morphology' card, the collapsed header should dynamically pull the three principal forms to remain useful even when closed. Similarly, each 'Sense' should display its 'Meaning Summary' in the header when collapsed, allowing the user to see an overview of all definitions at a glance.
+
+## Success criteria
+
+- **One-Click Interaction:** Users can expand/collapse cards with a single click on the header or a designated toggle icon.
+- **Morphology Summary:** When the 'Verb Morphology' card is collapsed, it must display the values of the Infinitiv, Präteritum, and Partizip II fields (e.g., "abdrehen, drehte ab, abgedreht").
+- **Conditional Visibility:** If a word is not a verb (and thus has no morphology data), the card 'Verb Morphology' should not be rendered at all.
+- **Independent Senses:** Each "Sense X" card operates independently; collapsing one does not affect the others.
+- **Sense Summary:** A collapsed "Sense X" card must display the text from its respective "Meaning Summary" field in the header.
+
+## Constraints
+
+- The collapsed state must not hide critical identification info (Meaning Summary/Principal Forms).
+- The implementation must handle multiple Senses (Sense 1, Sense 2, etc.) dynamically.
+
+## Desired tech
+
+- State management (local component state or a store) to track the `isCollapsed` boolean for each section.
+- Framer Motion or standard CSS transitions for smooth height animations during expansion/collapse.
+
+## Integration context
+
+- Must integrate into the existing `Edit Word` modal/form component.
+- The collapsed summary values must update in real-time if the user edits the fields while the card is expanded.
+
+## Known risks / concerns
+
+- **Empty Fields:** If a user collapses a card before filling in the 'Meaning Summary' or 'Principal Forms', the collapsed header might look empty or broken. We may need placeholder text (e.g., "No summary provided").
+- **Form Validation:** Ensure that hidden/collapsed fields still trigger validation errors if the user attempts to save.

--- a/.claude/rfc/4-collapsable-cards/rfc.md
+++ b/.claude/rfc/4-collapsable-cards/rfc.md
@@ -1,0 +1,176 @@
+# [RFC] Collapsible UI Components for Word Management — Vademecum Germanicum
+
+| Author              | Simone Porreca                                                                                                         |
+| :------------------ | :--------------------------------------------------------------------------------------------------------------------- |
+| **Project**         | Vademecum Germanicum                                                                                                   |
+| **RFC status**      | Draft                                                                                                                  |
+| **Review deadline** | 2026-05-12                                                                                                             |
+| **Notion page**     | [4-Collapsable Cards](https://www.notion.so/4-Collapsable-Cards-35c5cc6c0f0780fcaf30f0929b928375)                     |
+| **GitHub repo**     | [Volscente/vademecum-germanicum](https://github.com/Volscente/vademecum-germanicum)                                    |
+| **Milestone**       | [Milestone: 4-collapsable-cards](https://github.com/Volscente/vademecum-germanicum/milestone/4-collapsable-cards)      |
+
+### Timeline
+
+| Date       | Status | Note |
+| :--------- | :----- | :--- |
+| 2026-05-10 | Draft  |      |
+
+### Table of contents
+
+[Motivation](#motivation)
+
+[Objectives](#objectives)
+
+[Scope](#scope)
+
+[Collapsible UI Components for Word Management](#collapsible-ui-components-for-word-management-1)
+
+[Tech Stack](#tech-stack)
+
+[Effort Estimations](#effort-estimations)
+
+[FAQs](#faqs)
+
+[Risks & Open Questions](#risks--open-questions)
+
+[References](#references)
+
+---
+
+## Motivation {#motivation}
+
+The `EditWordModal` component presents all word data — basic details, verb morphology, and one or more Senses — in a single uninterrupted form, forcing the user to scroll through every section regardless of which part they actually need to inspect or edit. As the sense graph grows (multiple Senses, each with grammar patterns and example sentences), the modal becomes increasingly unwieldy, making it hard to quickly scan the word's data or locate a specific field without being distracted by secondary grammatical detail. Introducing per-card collapse behavior allows users to condense sections they are not currently editing into a single-line summary, reducing visual noise without hiding critical identification data. For full context, see the [Notion initiative page](https://www.notion.so/4-Collapsable-Cards-35c5cc6c0f0780fcaf30f0929b928375).
+
+## Objectives {#objectives}
+
+- **Enable per-card toggling**: Users can expand or collapse the Verb Morphology card and each individual Sense card independently with a single click on its header.
+- **Surface inline summaries**: Collapsed headers display a real-time summary derived from current form state — principal forms for Verb Morphology, Meaning Summary for each Sense — so the word remains readable without expanding every section.
+- **Hide absent cards**: The Verb Morphology card is not rendered when the word's category is not `verb`, eliminating empty sections for non-verb entries.
+- **Preserve form integrity**: All fields remain registered with react-hook-form regardless of collapsed state; a visible error indicator on the collapsed header surfaces validation failures without requiring the user to expand every card.
+- **Provide a global collapse control**: A single "Collapse All" button in the modal header condenses every collapsible card simultaneously.
+
+## Scope {#scope}
+
+**In-Scope:**
+
+- Interactive toggle functionality for the Verb Morphology card
+- Independent toggle functionality for each Sense X card
+- Summary view logic for collapsed Verb Morphology (Infinitiv, Präteritum, Partizip II)
+- Summary view logic for collapsed Senses (Meaning Summary)
+- Conditional rendering to hide the Verb Morphology card if no data is present (word category ≠ verb)
+- Global "Collapse All" button for every card
+
+**Out-of-Scope:**
+
+- **Drag-and-drop reordering of senses**: out of scope
+
+**Constraints:**
+
+- The collapsed header must always display critical identification info — Meaning Summary for Senses; Infinitiv, Präteritum, Partizip II for Verb Morphology — these values must never be hidden.
+- The implementation must handle a dynamic number of Sense cards (Sense 1, Sense 2, …) driven by `useFieldArray`.
+
+---
+
+# **Collapsible UI Components for Word Management** {#collapsible-ui-components-for-word-management-1}
+
+## Approach Overview {#approach-overview}
+
+All collapsible behavior is scoped entirely to `EditWordModal.tsx`. Two pieces of local React state track collapse status: a single `boolean` (`verbMorphologyCollapsed`) for the Verb Morphology card, and a `boolean[]` (`sensesCollapsed`) with one entry per sense, kept parallel to the `useFieldArray` `fields` array. Collapse and expand is implemented as a CSS-only toggle — adding `max-h-0 overflow-hidden` to the card body — so fields remain mounted in the DOM and stay registered with react-hook-form. Validation continues to fire for hidden fields, and a `formState.errors` check on the collapsed header exposes failures to the user. The collapsed header reads current field values via `useWatch`, so summary text updates in real-time as the user types without triggering a full form re-render.
+
+The author's proposed accordion-style direction is adopted in full with one deliberate refinement: fields are kept mounted (CSS-only hide) rather than unmounted on collapse. This ensures react-hook-form registration is preserved and validation errors in collapsed sections are caught before submission — a stated constraint. Framer Motion is noted as a desired option for animated height transitions, but is not introduced as a new dependency here: a CSS `transition-[max-height]` with a generous fixed upper bound achieves equivalent visual behavior with tools already in the stack.
+
+### Integration with EditWordModal {#integration-with-editwordmodal}
+
+`EditWordModal.tsx` is the sole integration point. No changes are required to `wordSchema.ts`, `api.ts`, `types/word.ts`, or any other component. The specific additions to `EditWordModal`:
+
+1. **State additions** — `verbMorphologyCollapsed: boolean` (default `false`) and `sensesCollapsed: boolean[]` (default all `false`, sized to `fields.length`). A `useEffect` dependent on `fields.length` keeps `sensesCollapsed` in sync when senses are appended or removed.
+2. **"Collapse All" button** — placed in the modal header row alongside existing controls; sets `verbMorphologyCollapsed = true` and every `sensesCollapsed` entry to `true`.
+3. **Card header pattern** — each collapsible card gets a header row containing: a `ChevronDown`/`ChevronUp` icon (already available via `lucide-react`), the card title, the summary text, and an optional error badge. For Verb Morphology, summary = `watch('principal_forms')` formatted as `"Infinitiv, Präteritum, Partizip II"` (placeholder `"—"` when empty). For Sense N, summary = `` watch(`senses.${n}.meaning_summary`) `` (placeholder `"No summary yet"` when empty).
+4. **Error indicator** — when `formState.errors` contains a key nested under a collapsed card (e.g., `errors.senses?.[n]` or `errors.principal_forms`), the collapsed header shows a small red dot so the user knows to expand that card before saving.
+5. **Conditional rendering** — the Verb Morphology card is wrapped in `{watch('category') === 'verb' && …}`, using the category field already present in the form.
+
+## Milestone 1 — Collapsible Verb Morphology Card {#milestone-1}
+
+Introduce `verbMorphologyCollapsed` state and the card header toggle for the Verb Morphology section. Add conditional rendering so the card is not shown when `category !== 'verb'`. Implement the collapsed summary header reading `principal_forms` via `useWatch`. Add the error indicator for this card.
+
+## Milestone 2 — Collapsible Sense Cards {#milestone-2}
+
+Introduce `sensesCollapsed: boolean[]` parallel to the `useFieldArray` `fields` array. Wrap each Sense card with an independent toggle. Implement the collapsed summary header reading `senses.N.meaning_summary` via `useWatch`. Sync `sensesCollapsed` with `fields` via `useEffect`. Add the error indicator for each Sense card.
+
+## Milestone 3 — Global "Collapse All" Button {#milestone-3}
+
+Add the "Collapse All" button to the modal header. When clicked, set `verbMorphologyCollapsed = true` and all `sensesCollapsed` entries to `true`. No new state is required; this milestone composes what M1 and M2 introduced.
+
+## Tech Stack {#tech-stack}
+
+- **react-hook-form (`useWatch`, `useFieldArray`, `formState.errors`)**: Already in use in `EditWordModal.tsx`. `useWatch` provides reactive field reads for real-time summary text; `formState.errors` drives the collapsed error indicator without any additional state.
+- **Tailwind CSS v4 (`transition-[max-height]`, `overflow-hidden`, `max-h-0`)**: Already in the stack. CSS max-height transitions on the card body deliver smooth collapse/expand with zero new dependencies.
+- **lucide-react (`ChevronDown`, `ChevronUp`)**: Already imported in the project for existing icons (Search, Trash2, Sparkles). Used for the toggle affordance on each card header.
+- **clsx / tailwind-merge**: Already used for conditional class merging throughout the frontend; applied to card bodies to toggle collapsed classes.
+
+**Desired / experimental:**
+
+- **Framer Motion** — identified by the author as a potential option for spring-based height animations. Not introduced in this RFC since the CSS transition approach satisfies the requirement with no new dependency; Framer Motion remains an upgrade path if the animation feel is later deemed insufficient.
+- **Local component state (`useState`)** — confirmed as appropriate here; no global store is needed since collapse state is ephemeral UI state relevant only within the open modal session.
+
+## Effort Estimations {#effort-estimations}
+
+Total estimated effort: **2.5 sessions**.
+
+| Milestone                             | Description                                                                              | Est. effort  | GitHub Issue |
+| :------------------------------------ | :--------------------------------------------------------------------------------------- | :----------- | :----------- |
+| M1 — Collapsible Verb Morphology Card | Toggle state, CSS collapse, summary header, conditional rendering, error indicator       | 1 session    | #{issue}     |
+| M2 — Collapsible Sense Cards          | Per-sense boolean array, useEffect sync, summary headers, per-card error indicators      | 1 session    | #{issue}     |
+| M3 — Global "Collapse All" Button     | Modal header button, bulk state update for all cards                                     | 0.5 sessions | #{issue}     |
+
+### Recommended Order
+
+1. M1 — Collapsible Verb Morphology Card (simpler single-boolean case; validates the card header pattern before scaling to the array)
+2. M2 — Collapsible Sense Cards (builds directly on M1's pattern; introduces dynamic array complexity)
+3. M3 — Global "Collapse All" Button (trivial once M1 and M2 state is in place)
+
+---
+
+# **FAQs** {#faqs}
+
+**Q: Why keep collapsed fields mounted in the DOM rather than unmounting them?**
+
+A: react-hook-form registers fields by name at mount time. If a field unmounts (because a card collapses), its registration is dropped — it is excluded from the submitted payload and from validation runs. Since a stated constraint is that hidden fields must still fail validation, fields must remain mounted. CSS-only hiding (`max-h-0 overflow-hidden`) achieves the visual collapse without unmounting, at the cost of slightly more DOM nodes — acceptable for this modal size.
+
+**Q: How does a user know a collapsed section contains a validation error?**
+
+A: The collapsed card header will display a small red error badge when `formState.errors` contains at least one key nested under that card (e.g., `errors.senses?.[0]?.meaning_summary` for Sense 1, `errors.principal_forms` for Verb Morphology). The badge makes the failure visible without forcing the user to expand every section to hunt for red fields.
+
+**Q: Why use a parallel `boolean[]` for senses instead of a `Map<string, boolean>` keyed by the field's stable ID?**
+
+A: Collapse state is purely ephemeral UI state. A parallel array keeps the implementation simple and avoids reconciling a Map with `useFieldArray` mutations (append/remove shift indices). The `useEffect` sync resets the array to the correct length on every change to `fields.length`, which is the only invariant that needs to hold.
+
+**Q: What happens to collapse state when Re-enrich replaces all senses?**
+
+A: Re-enrich calls `reset()` on the form, which triggers `useFieldArray` to repopulate `fields`. The `useEffect` watching `fields.length` will resize `sensesCollapsed` to all `false`, effectively expanding every Sense card. This is the correct behavior — the user should review newly populated data.
+
+**Q: Terminology?**
+
+A:
+
+- **Sense** → A distinct meaning of the word, containing a Meaning Summary, grammar patterns, and example sentences. A word may have multiple Senses (Sense 1, Sense 2, …).
+- **Verb Morphology** → The form section containing `auxiliary_verb` and `principal_forms`; only shown when `category === "verb"`.
+- **Principal Forms** → The three conjugated forms that identify a German verb: Infinitiv, Präteritum, Partizip II (e.g., "abdrehen, drehte ab, abgedreht").
+- **RHF** → react-hook-form, the form state and validation library used in both `AddWordModal` and `EditWordModal`.
+
+---
+
+## Risks & Open Questions {#risks--open-questions}
+
+| Risk / Question                                                                                                          | Likelihood | Mitigation / Answer                                                                                                                                                                     |
+| :----------------------------------------------------------------------------------------------------------------------- | :--------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Collapsed header looks empty if Principal Forms or Meaning Summary are not yet filled                                    | High       | Show a styled placeholder string (`"—"` for principal forms, `"No summary yet"` for senses) in the collapsed header when the watched value is empty or undefined.                       |
+| Validation errors in a collapsed section are invisible, potentially confusing the user after a failed save               | Medium     | Render a red error badge on the collapsed header keyed to `formState.errors`; consider auto-expanding cards that contain errors when the user attempts to submit.                       |
+| `sensesCollapsed` array goes out of sync with `fields` after rapid append/remove operations                              | Low        | `useEffect` dependent on `fields.length` resets the array on every length change: truncate on remove, push `false` on append.                                                          |
+| CSS `max-height` transition requires a hardcoded upper bound and may clip very tall Sense cards with many grammar entries | Low        | Use a generous bound (e.g., `max-h-[2000px]`) with a moderate transition duration; revisit if clipping is observed in practice after implementation.                                    |
+
+## References {#references}
+
+- [react-hook-form — useWatch](https://react-hook-form.com/docs/usewatch)
+- [react-hook-form — useFieldArray](https://react-hook-form.com/docs/usefieldarray)
+- [Notion Initiative Page](https://www.notion.so/4-Collapsable-Cards-35c5cc6c0f0780fcaf30f0929b928375)

--- a/.claude/rfc/4-collapsable-cards/rfc.md
+++ b/.claude/rfc/4-collapsable-cards/rfc.md
@@ -119,9 +119,9 @@ Total estimated effort: **2.5 sessions**.
 
 | Milestone                             | Description                                                                              | Est. effort  | GitHub Issue |
 | :------------------------------------ | :--------------------------------------------------------------------------------------- | :----------- | :----------- |
-| M1 — Collapsible Verb Morphology Card | Toggle state, CSS collapse, summary header, conditional rendering, error indicator       | 1 session    | #{issue}     |
-| M2 — Collapsible Sense Cards          | Per-sense boolean array, useEffect sync, summary headers, per-card error indicators      | 1 session    | #{issue}     |
-| M3 — Global "Collapse All" Button     | Modal header button, bulk state update for all cards                                     | 0.5 sessions | #{issue}     |
+| M1 — Collapsible Verb Morphology Card | Toggle state, CSS collapse, summary header, conditional rendering, error indicator       | 1 session    | #47{issue}     |
+| M2 — Collapsible Sense Cards          | Per-sense boolean array, useEffect sync, summary headers, per-card error indicators      | 1 session    | #48{issue}     |
+| M3 — Global "Collapse All" Button     | Modal header button, bulk state update for all cards                                     | 0.5 sessions | #49{issue}     |
 
 ### Recommended Order
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] - 2026-05-10
+
+### Changed
+
+- **Frontend**: `EditWordModal` Sense cards are now independently collapsible — click the section header to toggle expand/collapse. Collapsed header displays the Meaning Summary text (or "No summary yet" when empty) and a red error badge when the card contains a validation error. A `sensesCollapsed: boolean[]` state array, indexed parallel to `useFieldArray` `fields`, tracks per-card state; a `useEffect` keeps it in sync on append, remove, and Re-enrich reset. Fields remain mounted (CSS-only `max-height` toggle) so react-hook-form registration and validation are preserved in both states.
+
 ## [0.3.3] - 2026-05-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.5] - 2026-05-10
+
+### Added
+
+- **Frontend**: "Collapse All" button in `EditWordModal`, placed just above the Verb Morphology card. A single click sets `verbMorphologyCollapsed = true` and maps all `sensesCollapsed` entries to `true`, condensing the entire modal to summary headers in one action.
+
 ## [0.3.4] - 2026-05-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2026-05-10
+
+### Changed
+
+- **Frontend**: `EditWordModal` Verb Morphology card is now collapsible — click the section header to toggle expand/collapse. Collapsed header displays a real-time summary of the three principal forms (Infinitiv · Präteritum · Partizip II) or `"—"` when empty. A red error badge on the collapsed header surfaces `auxiliary_verb` / `principal_forms` validation errors without requiring the user to expand the card. Fields remain mounted in the DOM (CSS-only `max-height` toggle) so react-hook-form registration and validation are preserved in both states.
+
 ## [0.3.2] - 2026-05-09
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "backend"
-version = "0.3.3"
+version = "0.3.4"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Simone Porreca", email = "porrecasimone@gmail.com" }]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "backend"
-version = "0.3.2"
+version = "0.3.3"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Simone Porreca", email = "porrecasimone@gmail.com" }]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -59,6 +59,10 @@ A Next.js 16 single-page application that provides the user interface for Vademe
 
 ## Changelog
 
+### 2026-05-10 (v0.3.5)
+
+- Updated `EditWordModal.tsx`: added a "Collapse All" button just above the Verb Morphology card. Clicking it sets `verbMorphologyCollapsed = true` and maps all `sensesCollapsed` entries to `true` via a `handleCollapseAll` handler, condensing the entire modal to summary headers in one action.
+
 ### 2026-05-10 (v0.3.4)
 
 - Updated `EditWordModal.tsx`: each Sense card is now independently collapsible — click the header to toggle. Collapsed header shows the Meaning Summary (or "No summary yet" when empty) and a red error badge when the Sense has a validation error. Added `sensesCollapsed: boolean[]` state, a `useEffect` that keeps the array in sync with `useFieldArray` `fields` (handles append, remove, and Re-enrich reset), and `toggleSenseCollapsed(index)` handler. Fields remain mounted (CSS-only max-height toggle) so react-hook-form registration and validation are preserved in both states.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -59,6 +59,10 @@ A Next.js 16 single-page application that provides the user interface for Vademe
 
 ## Changelog
 
+### 2026-05-10 (v0.3.3)
+
+- Updated `EditWordModal.tsx`: Verb Morphology card is now collapsible — click the header to toggle; collapsed header shows a real-time principal-forms summary (Infinitiv · Präteritum · Partizip II, or "—" when empty); red error badge appears on the collapsed header when `principal_forms` or `auxiliary_verb` has a validation error; fields remain mounted (CSS-only collapse) so react-hook-form registration is preserved. Added `verbMorphologyCollapsed` state, `useWatch` for `principal_forms`, and `clsx`-driven `max-h` toggle.
+
 ### 2026-05-09 (v0.3.2)
 
 - Updated `word.ts`: added `Sense`, `GrammarPattern`, `ExampleSentence` interfaces; extended `Word` with `auxiliary_verb`, `principal_forms`, and `senses`; updated `WordEnrichment` to sense-based shape (removes old flat fields).

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -59,6 +59,10 @@ A Next.js 16 single-page application that provides the user interface for Vademe
 
 ## Changelog
 
+### 2026-05-10 (v0.3.4)
+
+- Updated `EditWordModal.tsx`: each Sense card is now independently collapsible — click the header to toggle. Collapsed header shows the Meaning Summary (or "No summary yet" when empty) and a red error badge when the Sense has a validation error. Added `sensesCollapsed: boolean[]` state, a `useEffect` that keeps the array in sync with `useFieldArray` `fields` (handles append, remove, and Re-enrich reset), and `toggleSenseCollapsed(index)` handler. Fields remain mounted (CSS-only max-height toggle) so react-hook-form registration and validation are preserved in both states.
+
 ### 2026-05-10 (v0.3.3)
 
 - Updated `EditWordModal.tsx`: Verb Morphology card is now collapsible — click the header to toggle; collapsed header shows a real-time principal-forms summary (Infinitiv · Präteritum · Partizip II, or "—" when empty); red error badge appears on the collapsed header when `principal_forms` or `auxiliary_verb` has a validation error; fields remain mounted (CSS-only collapse) so react-hook-form registration is preserved. Added `verbMorphologyCollapsed` state, `useWatch` for `principal_forms`, and `clsx`-driven `max-h` toggle.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/components/EditWordModal.tsx
+++ b/frontend/src/components/EditWordModal.tsx
@@ -2,9 +2,10 @@ import { enrichWord, updateWord } from "@/lib/api";
 import { WordFormValues, wordSchema } from "@/lib/wordSchema";
 import { Word } from "@/types/word";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { PlusCircle, RefreshCw, Trash2 } from "lucide-react";
+import { clsx } from "clsx";
+import { ChevronDown, ChevronUp, PlusCircle, RefreshCw, Trash2 } from "lucide-react";
 import { useEffect, useState } from "react";
-import { useFieldArray, useForm } from "react-hook-form";
+import { useFieldArray, useForm, useWatch } from "react-hook-form";
 
 interface EditWordModalProps {
   word: Word;
@@ -62,6 +63,7 @@ export default function EditWordModal({
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [isEnriching, setIsEnriching] = useState(false);
   const [enrichError, setEnrichError] = useState<string | null>(null);
+  const [verbMorphologyCollapsed, setVerbMorphologyCollapsed] = useState(false);
 
   const {
     register,
@@ -88,6 +90,13 @@ export default function EditWordModal({
 
   const watchedSenses = watch("senses") ?? [];
   const watchedCategory = watch("category");
+
+  const watchedPrincipalForms = useWatch({ control, name: "principal_forms" });
+  const verbMorphologySummary =
+    watchedPrincipalForms?.[0] && watchedPrincipalForms?.[1] && watchedPrincipalForms?.[2]
+      ? `${watchedPrincipalForms[0]} · ${watchedPrincipalForms[1]} · ${watchedPrincipalForms[2]}`
+      : "—";
+  const verbMorphologyHasError = !!errors.principal_forms || !!errors.auxiliary_verb;
 
   // Guard comes after all hooks
   if (!isOpen) return null;
@@ -220,32 +229,63 @@ export default function EditWordModal({
 
           {/* Verb Morphology — shown only when auxiliary_verb is set or category is verb */}
           {(watchedCategory === "verb" || word.auxiliary_verb) && (
-            <div className="border border-forest-200 dark:border-forest-600 rounded-lg p-3 space-y-3">
-              <p className="text-xs font-semibold text-forest-600 dark:text-forest-300 uppercase tracking-wide">
-                Verb Morphology
-              </p>
-              <div>
-                <label className={labelClass}>Auxiliary Verb</label>
-                <select {...register("auxiliary_verb")} className={inputClass}>
-                  <option value="">—</option>
-                  <option value="haben">haben</option>
-                  <option value="sein">sein</option>
-                </select>
-              </div>
-              <div>
-                <label className={labelClass}>Principal Forms</label>
-                <div className="grid grid-cols-3 gap-2 mt-1">
-                  {["Infinitiv", "Präteritum", "Partizip II"].map((label, i) => (
-                    <div key={label}>
-                      <p className="text-xs text-forest-500 dark:text-forest-400 mb-1">
-                        {label}
-                      </p>
-                      <input
-                        {...register(`principal_forms.${i}`)}
-                        className={inputClass}
-                      />
+            <div className="border border-forest-200 dark:border-forest-600 rounded-lg p-3">
+              <button
+                type="button"
+                onClick={() => setVerbMorphologyCollapsed((prev) => !prev)}
+                className="flex w-full items-center gap-2"
+              >
+                {verbMorphologyCollapsed ? (
+                  <ChevronDown className="w-3 h-3 text-forest-600 dark:text-forest-300" />
+                ) : (
+                  <ChevronUp className="w-3 h-3 text-forest-600 dark:text-forest-300" />
+                )}
+                <span className="text-xs font-semibold text-forest-600 dark:text-forest-300 uppercase tracking-wide">
+                  Verb Morphology
+                </span>
+                {verbMorphologyCollapsed && (
+                  <span className="ml-2 text-xs text-forest-500 dark:text-forest-400">
+                    {verbMorphologySummary}
+                  </span>
+                )}
+                {verbMorphologyHasError && (
+                  <span
+                    className="ml-auto h-2 w-2 rounded-full bg-red-500"
+                    aria-label="Contains errors"
+                  />
+                )}
+              </button>
+              <div
+                className={clsx(
+                  "overflow-hidden transition-[max-height] duration-300",
+                  verbMorphologyCollapsed ? "max-h-0" : "max-h-500",
+                )}
+              >
+                <div className="space-y-3 pt-3">
+                  <div>
+                    <label className={labelClass}>Auxiliary Verb</label>
+                    <select {...register("auxiliary_verb")} className={inputClass}>
+                      <option value="">—</option>
+                      <option value="haben">haben</option>
+                      <option value="sein">sein</option>
+                    </select>
+                  </div>
+                  <div>
+                    <label className={labelClass}>Principal Forms</label>
+                    <div className="grid grid-cols-3 gap-2 mt-1">
+                      {["Infinitiv", "Präteritum", "Partizip II"].map((label, i) => (
+                        <div key={label}>
+                          <p className="text-xs text-forest-500 dark:text-forest-400 mb-1">
+                            {label}
+                          </p>
+                          <input
+                            {...register(`principal_forms.${i}`)}
+                            className={inputClass}
+                          />
+                        </div>
+                      ))}
                     </div>
-                  ))}
+                  </div>
                 </div>
               </div>
             </div>

--- a/frontend/src/components/EditWordModal.tsx
+++ b/frontend/src/components/EditWordModal.tsx
@@ -119,6 +119,11 @@ export default function EditWordModal({
     );
   };
 
+  const handleCollapseAll = (): void => {
+    setVerbMorphologyCollapsed(true);
+    setSensesCollapsed((prev) => prev.map(() => true));
+  };
+
   const handleDelete = async () => {
     if (!confirm(`Are you sure you want to delete "${word.word}"?`)) return;
 
@@ -243,6 +248,18 @@ export default function EditWordModal({
           <div>
             <label className={labelClass}>Plural</label>
             <input {...register("word_plural")} className={inputClass} />
+          </div>
+
+          {/* Collapse All */}
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={handleCollapseAll}
+              className="text-xs text-forest-600 dark:text-forest-300 hover:text-forest-800 dark:hover:text-forest-100 flex items-center gap-1"
+            >
+              <ChevronDown className="w-3 h-3" />
+              Collapse All
+            </button>
           </div>
 
           {/* Verb Morphology — shown only when auxiliary_verb is set or category is verb */}

--- a/frontend/src/components/EditWordModal.tsx
+++ b/frontend/src/components/EditWordModal.tsx
@@ -64,6 +64,7 @@ export default function EditWordModal({
   const [isEnriching, setIsEnriching] = useState(false);
   const [enrichError, setEnrichError] = useState<string | null>(null);
   const [verbMorphologyCollapsed, setVerbMorphologyCollapsed] = useState(false);
+  const [sensesCollapsed, setSensesCollapsed] = useState<boolean[]>([]);
 
   const {
     register,
@@ -88,6 +89,17 @@ export default function EditWordModal({
     reset(buildDefaultValues(word));
   }, [word, reset]);
 
+  // Keep sensesCollapsed parallel to senseFields — push false for new entries, truncate on remove.
+  // Re-enrich calls reset() which repopulates senseFields from zero, expanding all cards.
+  useEffect(() => {
+    setSensesCollapsed((prev) => {
+      if (senseFields.length > prev.length) {
+        return [...prev, ...Array(senseFields.length - prev.length).fill(false)];
+      }
+      return prev.slice(0, senseFields.length);
+    });
+  }, [senseFields.length]);
+
   const watchedSenses = watch("senses") ?? [];
   const watchedCategory = watch("category");
 
@@ -100,6 +112,12 @@ export default function EditWordModal({
 
   // Guard comes after all hooks
   if (!isOpen) return null;
+
+  const toggleSenseCollapsed = (index: number): void => {
+    setSensesCollapsed((prev) =>
+      prev.map((collapsed, i) => (i === index ? !collapsed : collapsed)),
+    );
+  };
 
   const handleDelete = async () => {
     if (!confirm(`Are you sure you want to delete "${word.word}"?`)) return;
@@ -313,12 +331,35 @@ export default function EditWordModal({
               {senseFields.map((field, sIdx) => (
                 <div
                   key={field.id}
-                  className="border border-forest-200 dark:border-forest-600 rounded-lg p-3 space-y-3"
+                  className="border border-forest-200 dark:border-forest-600 rounded-lg p-3"
                 >
-                  <div className="flex items-center justify-between">
-                    <p className="text-xs font-semibold text-forest-600 dark:text-forest-300 uppercase tracking-wide">
-                      Sense {sIdx + 1}
-                    </p>
+                  {/* Card Header */}
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => toggleSenseCollapsed(sIdx)}
+                      className="flex flex-1 items-center gap-2"
+                    >
+                      {sensesCollapsed[sIdx] ? (
+                        <ChevronDown className="w-3 h-3 text-forest-600 dark:text-forest-300" />
+                      ) : (
+                        <ChevronUp className="w-3 h-3 text-forest-600 dark:text-forest-300" />
+                      )}
+                      <span className="text-xs font-semibold text-forest-600 dark:text-forest-300 uppercase tracking-wide">
+                        Sense {sIdx + 1}
+                      </span>
+                      {sensesCollapsed[sIdx] && (
+                        <span className="text-xs text-forest-500 dark:text-forest-400 truncate">
+                          {watchedSenses[sIdx]?.meaning_summary || "No summary yet"}
+                        </span>
+                      )}
+                      {!!errors.senses?.[sIdx] && sensesCollapsed[sIdx] && (
+                        <span
+                          className="ml-auto h-2 w-2 rounded-full bg-red-500"
+                          aria-label="Contains errors"
+                        />
+                      )}
+                    </button>
                     <button
                       type="button"
                       onClick={() => remove(sIdx)}
@@ -329,90 +370,100 @@ export default function EditWordModal({
                     </button>
                   </div>
 
-                  {/* Meaning Summary */}
-                  <div>
-                    <label className={labelClass}>Meaning Summary</label>
-                    <input
-                      {...register(`senses.${sIdx}.meaning_summary`)}
-                      className={inputClass}
-                    />
-                    {errors.senses?.[sIdx]?.meaning_summary && (
-                      <p className="text-red-500 text-xs">
-                        {errors.senses[sIdx].meaning_summary?.message}
-                      </p>
+                  {/* Card Body */}
+                  <div
+                    className={clsx(
+                      "overflow-hidden transition-[max-height] duration-300",
+                      sensesCollapsed[sIdx] ? "max-h-0" : "max-h-500",
                     )}
-                  </div>
+                  >
+                    <div className="space-y-3 pt-3">
+                      {/* Meaning Summary */}
+                      <div>
+                        <label className={labelClass}>Meaning Summary</label>
+                        <input
+                          {...register(`senses.${sIdx}.meaning_summary`)}
+                          className={inputClass}
+                        />
+                        {errors.senses?.[sIdx]?.meaning_summary && (
+                          <p className="text-red-500 text-xs">
+                            {errors.senses[sIdx].meaning_summary?.message}
+                          </p>
+                        )}
+                      </div>
 
-                  {/* Register */}
-                  <div>
-                    <label className={labelClass}>Register</label>
-                    <select
-                      {...register(`senses.${sIdx}.register`)}
-                      className={inputClass}
-                    >
-                      <option value="Neutral">Neutral</option>
-                      <option value="Formal">Formal</option>
-                      <option value="Colloquial">Colloquial</option>
-                      <option value="Technical">Technical</option>
-                    </select>
-                  </div>
+                      {/* Register */}
+                      <div>
+                        <label className={labelClass}>Register</label>
+                        <select
+                          {...register(`senses.${sIdx}.register`)}
+                          className={inputClass}
+                        >
+                          <option value="Neutral">Neutral</option>
+                          <option value="Formal">Formal</option>
+                          <option value="Colloquial">Colloquial</option>
+                          <option value="Technical">Technical</option>
+                        </select>
+                      </div>
 
-                  {/* Grammar Patterns */}
-                  <div>
-                    <p className="text-xs font-medium text-forest-600 dark:text-forest-300 mb-1">
-                      Grammar Patterns
-                    </p>
-                    {(watchedSenses[sIdx]?.grammar_patterns ?? []).map(
-                      (_, gpIdx) => (
-                        <div key={gpIdx} className="flex gap-2 mt-1">
-                          <input
-                            {...register(
-                              `senses.${sIdx}.grammar_patterns.${gpIdx}.preposition`,
-                            )}
-                            placeholder="Preposition (optional)"
-                            className={inputClass}
-                          />
-                          <select
-                            {...register(
-                              `senses.${sIdx}.grammar_patterns.${gpIdx}.case`,
-                            )}
-                            className={inputClass}
-                          >
-                            <option value="Akkusativ">Akkusativ</option>
-                            <option value="Dativ">Dativ</option>
-                            <option value="Nominativ">Nominativ</option>
-                            <option value="Genitiv">Genitiv</option>
-                          </select>
-                        </div>
-                      ),
-                    )}
-                  </div>
+                      {/* Grammar Patterns */}
+                      <div>
+                        <p className="text-xs font-medium text-forest-600 dark:text-forest-300 mb-1">
+                          Grammar Patterns
+                        </p>
+                        {(watchedSenses[sIdx]?.grammar_patterns ?? []).map(
+                          (_, gpIdx) => (
+                            <div key={gpIdx} className="flex gap-2 mt-1">
+                              <input
+                                {...register(
+                                  `senses.${sIdx}.grammar_patterns.${gpIdx}.preposition`,
+                                )}
+                                placeholder="Preposition (optional)"
+                                className={inputClass}
+                              />
+                              <select
+                                {...register(
+                                  `senses.${sIdx}.grammar_patterns.${gpIdx}.case`,
+                                )}
+                                className={inputClass}
+                              >
+                                <option value="Akkusativ">Akkusativ</option>
+                                <option value="Dativ">Dativ</option>
+                                <option value="Nominativ">Nominativ</option>
+                                <option value="Genitiv">Genitiv</option>
+                              </select>
+                            </div>
+                          ),
+                        )}
+                      </div>
 
-                  {/* Example Sentences */}
-                  <div>
-                    <p className="text-xs font-medium text-forest-600 dark:text-forest-300 mb-1">
-                      Example Sentences
-                    </p>
-                    {(watchedSenses[sIdx]?.example_sentences ?? []).map(
-                      (_, exIdx) => (
-                        <div key={exIdx} className="space-y-1 mt-1">
-                          <input
-                            {...register(
-                              `senses.${sIdx}.example_sentences.${exIdx}.german`,
-                            )}
-                            placeholder="German sentence"
-                            className={inputClass}
-                          />
-                          <input
-                            {...register(
-                              `senses.${sIdx}.example_sentences.${exIdx}.english`,
-                            )}
-                            placeholder="English translation"
-                            className={inputClass}
-                          />
-                        </div>
-                      ),
-                    )}
+                      {/* Example Sentences */}
+                      <div>
+                        <p className="text-xs font-medium text-forest-600 dark:text-forest-300 mb-1">
+                          Example Sentences
+                        </p>
+                        {(watchedSenses[sIdx]?.example_sentences ?? []).map(
+                          (_, exIdx) => (
+                            <div key={exIdx} className="space-y-1 mt-1">
+                              <input
+                                {...register(
+                                  `senses.${sIdx}.example_sentences.${exIdx}.german`,
+                                )}
+                                placeholder="German sentence"
+                                className={inputClass}
+                              />
+                              <input
+                                {...register(
+                                  `senses.${sIdx}.example_sentences.${exIdx}.english`,
+                                )}
+                                placeholder="English translation"
+                                className={inputClass}
+                              />
+                            </div>
+                          ),
+                        )}
+                      </div>
+                    </div>
                   </div>
                 </div>
               ))}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vademecum-germanicum"
-version = "0.3.2"
+version = "0.3.3"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vademecum-germanicum"
-version = "0.3.4"
+version = "0.3.5"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vademecum-germanicum"
-version = "0.3.3"
+version = "0.3.4"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Description

The PR resolves the issue #49 by adding a "Collapse All" button.

## Changelog

### Changed

- **Frontend**: "Collapse All" button in `EditWordModal`, placed just above the Verb Morphology card. A single click sets `verbMorphologyCollapsed = true` and maps all `sensesCollapsed` entries to `true`, condensing the entire modal to summary headers in one action.

## Checklist

### Mandatory

- [x] The title of the Pull Request starts with the JIRA ticket number (if provided)
- [x] The title of the Pull Request must reflect the corresponding issue title
- [x] It has to have a `Description` section, specifying which is the `#issue` it's resolving and how
- [x] It has to have a `Changelog` section, reporting what has been changed in the corresponding issue
- [x] The project version must have been updated

### Optional

- [x] Update the Wiki
- [x] Update the `README.md`
- [x] Update the `CHANGELOG.md`
