### PR TITLE
Feat/56 Learning area

### DIFF
--- a/.claude/planning/5-review-feature/56-learning-area-ui-senses-table-and-review-cart.md
+++ b/.claude/planning/5-review-feature/56-learning-area-ui-senses-table-and-review-cart.md
@@ -1,0 +1,169 @@
+# #56: Learning Area UI — Senses Table and Review Cart
+
+**GitHub Issue:** [#56 — Learning Area](https://github.com/Volscente/vademecum-germanicum/issues/56)
+**GitHub Milestone:** [Milestone: 5-review-feature](https://github.com/Volscente/vademecum-germanicum/milestone/7)
+**Notion page:** [5 - Review Feature](https://www.notion.so/5-Review-Feature-3575cc6c0f0780c6a2beeedca2095b11)
+
+---
+
+## Technical Scope
+
+**In scope:**
+
+- `frontend/src/app/page.tsx` — Add `area` and `reviewQueue` state; wire `AreaToggle` above the content pane (hidden when `area === "review"`); conditionally render `WordTable` vs `SensesTable` vs `ReviewArea` placeholder based on `area`
+- `frontend/src/components/AreaToggle.tsx` — New component: pill-style toggle switch between `"vocabulary"` and `"learning"` areas, styled with the existing `forest-*` Tailwind palette
+- `frontend/src/components/SensesTable.tsx` — New component: fetches all senses via `getSenses()` on mount, renders a table with columns (Word, Translation, Category, Difficulty Level, Last Reviewed, To Review badge), checkbox per row for multi-select, and a "Start Review" button visible when at least one row is selected
+
+**Out of scope:**
+
+- `ReviewArea` and `SenseCard` components — built in TASK-3; a minimal `<div>` placeholder suffices here
+- Difficulty button API calls and card transition animation — wired in TASK-4
+- Any backend changes — fully completed in TASK-1 (`GET /senses/`, `PUT /senses/{sense_id}/review`, `getSenses()`, `updateSenseReview()`, `toReview()`, `SenseWithWord` type)
+- Search or filter within the Senses Table
+
+---
+
+## Architecture
+
+```txt
+page.tsx
+    │  area: "vocabulary" | "learning" | "review"
+    │  reviewQueue: SenseWithWord[]
+    │
+    ├── <AreaToggle area onAreaChange />   (rendered above content pane; hidden when area === "review")
+    │
+    ├─[area === "vocabulary"]──► <WordTable words onRefresh />
+    │
+    ├─[area === "learning"]────► <SensesTable
+    │                                onStartReview={(selected) => {
+    │                                  setReviewQueue(selected)
+    │                                  setArea("review")
+    │                                }}
+    │                            />
+    │                              │
+    │                              ├── getSenses() ──► GET /senses/ ──► SenseWithWord[]
+    │                              ├── toReview(sense) ──► boolean  (per-row badge)
+    │                              └── selectedSenseIds: Set<number>  (local state)
+    │
+    └─[area === "review"]──────► <div>Review Area placeholder</div>  (TASK-3)
+```
+
+### Why area state lives in page.tsx
+
+`reviewQueue` must outlive `SensesTable` — it is consumed by `ReviewArea`, which is a sibling rendered at the same level. Lifting both `area` and `reviewQueue` to `page.tsx` is consistent with the established pattern where all cross-component state (`words`, `searchTerm`, modal open/close) already lives in the root page. `selectedSenseIds` is kept local to `SensesTable` because nothing outside that component needs it.
+
+---
+
+## Tech Stack
+
+No new packages required. All dependencies (`lucide-react`, `tailwindcss`, `clsx`) are already installed.
+
+---
+
+## Implementation Details
+
+### Modules / Files
+
+| File | Action | Description |
+| ---- | ------ | ----------- |
+| `frontend/src/app/page.tsx` | Modify | Add `area` and `reviewQueue` state; render `AreaToggle` (hidden in review mode); conditional content rendering |
+| `frontend/src/components/AreaToggle.tsx` | Create | Pill toggle between `"vocabulary"` and `"learning"` |
+| `frontend/src/components/SensesTable.tsx` | Create | Senses table with multi-select checkboxes, To Review badge, and Start Review button |
+
+---
+
+### Key Functions
+
+```typescript
+// page.tsx — handler passed to SensesTable
+function handleStartReview(selected: SenseWithWord[]): void
+// Sets reviewQueue = selected, then area = "review".
+// selected preserves the row order from SensesTable.
+```
+
+```typescript
+// AreaToggle.tsx
+type Area = "vocabulary" | "learning";
+
+interface AreaToggleProps {
+  area: Area;
+  onAreaChange: (area: Area) => void;
+}
+// Pill-style toggle; clicking the inactive pill calls onAreaChange with the new value.
+// Does not render when area === "review" (ReviewArea has its own exit controls).
+```
+
+```typescript
+// SensesTable.tsx
+interface SensesTableProps {
+  onStartReview: (selected: SenseWithWord[]) => void;
+}
+// Calls getSenses() on mount. Maintains selectedSenseIds: Set<number> as local state.
+// Renders one table row per SenseWithWord; each row has a checkbox bound to local selection.
+// difficulty_level is displayed as-is; null is treated as "Medium" for display purposes.
+// "Start Review" button is rendered (and enabled) only when selectedSenseIds.size > 0.
+// On "Start Review" click: resolves the ordered SenseWithWord[] from the current senses
+// array preserving row order, then calls onStartReview(selected).
+```
+
+---
+
+### Data Models / Schemas
+
+All types are already defined in `frontend/src/types/word.ts` (TASK-1 deliverable). No new types are required.
+
+```typescript
+// Relevant existing interfaces (for reference):
+
+interface SenseWithWord {
+  id: number;
+  word: string;
+  translation: string;
+  gender: string;
+  category: string;
+  meaning_summary: string;
+  register: string;
+  grammar_patterns: GrammarPattern[];
+  example_sentences: ExampleSentence[];
+  difficulty_level: string | null;   // DifficultyLevelEnum value or null
+  last_reviewed_at: string | null;   // ISO timestamp or null
+}
+```
+
+`toReview(sense: SenseWithWord): boolean` is already implemented in `frontend/src/lib/reviewUtils.ts`.
+
+---
+
+### Testing Strategy
+
+**Manual integration test (golden path):**
+
+```bash
+just dev
+# Open http://localhost:3000
+```
+
+1. Verify the `AreaToggle` renders above the word table.
+2. Click "Learning" — `SensesTable` replaces `WordTable`; rows load from `GET /senses/`.
+3. Verify all six columns render (Word, Translation, Category, Difficulty Level, Last Reviewed, To Review badge).
+4. Verify senses with `last_reviewed_at = null` always show the To Review badge.
+5. Click one checkbox — "Start Review" button appears.
+6. Click "Start Review" — content pane transitions to the `ReviewArea` placeholder; `area === "review"`.
+7. Toggle back to "Vocabulary" via `AreaToggle` (if rendered) or via the placeholder — `WordTable` restores; existing `words` state is unchanged.
+
+**Edge cases:**
+
+- No senses in the database → `SensesTable` renders an empty table body with no "Start Review" button
+- All rows selected → "Start Review" fires with the full ordered senses array
+- `difficulty_level = null` → rendered as `"Medium"`
+- Toggling from Learning back to Vocabulary while rows are selected → `selectedSenseIds` persists in `page.tsx`; re-entering Learning re-shows the prior selection
+
+---
+
+### Open Questions / Risks
+
+All open questions resolved:
+
+- **`selectedSenseIds` placement:** kept local to `SensesTable` — nothing outside the component needs it.
+- **`AreaToggle` in Review Area:** not rendered when `area === "review"`.
+- **`difficulty_level = null` display:** shown as `"Medium"`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-05-23
+
+### Added
+
+- **Frontend**: New `AreaToggle` React component — pill-style toggle switch between Vocabulary and Learning areas, styled with the `forest-*` Tailwind palette; hidden when the Review Area is active.
+- **Frontend**: New `SensesTable` React component — Learning Area table that fetches all senses from `GET /senses/`, renders To Review badges via `toReview()`, supports multi-select checkboxes with local state, and triggers the review session via `onStartReview`.
+
+### Changed
+
+- **Frontend**: `page.tsx` extended with `area` (`"vocabulary" | "learning" | "review"`) and `reviewQueue: SenseWithWord[]` state; `SearchBar` rendered only in Vocabulary Area; `AreaToggle` rendered above the content pane (hidden when `area === "review"`); content pane now conditionally renders `WordTable`, `SensesTable`, or a Review Area placeholder based on `area`.
+
 ## [0.4.0] - 2026-05-23
 
 ### Added

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,7 +6,9 @@ A Next.js 16 single-page application that provides the user interface for Vademe
 
 ## Key components
 
-- **`src/app/page.tsx`** — Root page; owns all state (words list, search term, loading flag), fetches from the backend, and passes handlers down to child components
+- **`src/app/page.tsx`** — Root page; owns all state (words list, search term, loading flag, active area, review queue), fetches from the backend, and passes handlers down to child components
+- **`src/components/AreaToggle.tsx`** — Pill-style toggle switch between the Vocabulary Area and the Learning Area; hidden when the Review Area is active
+- **`src/components/SensesTable.tsx`** — Senses table for the Learning Area; fetches all senses via `getSenses()`, renders per-row To Review badges via `toReview()`, maintains local multi-select state, and fires `onStartReview` with the selected senses
 - **`src/components/AddWordModal.tsx`** — Modal form for creating a new word entry; includes an "Enrich" button that calls the AI enrichment API to pre-populate fields
 - **`src/components/EditWordModal.tsx`** — Full edit form for updating word data (all fields including nested senses) with a delete action; opened by clicking a row in WordTable
 - **`src/components/WordTable.tsx`** — Displays the vocabulary as a clickable table; clicking a row opens EditWordModal
@@ -20,6 +22,8 @@ A Next.js 16 single-page application that provides the user interface for Vademe
 
 ## Public interfaces
 
+- `<AreaToggle area onAreaChange>` — pill toggle between `"vocabulary"` and `"learning"`; not rendered when `area === "review"`
+- `<SensesTable onStartReview>` — senses table with multi-select checkboxes and "Start Review" button; calls `onStartReview(selected: SenseWithWord[])` to hand off the review queue
 - `<AddWordModal onWordAdded>` — button + modal to create a word; calls `onWordAdded()` after a successful save
 - `<EditWordModal word isOpen onClose onWordDeleted onWordUpdated>` — full edit form for all word fields including senses; calls `onWordUpdated` after a successful save and `onWordDeleted` after deletion
 - `<WordTable words onRefresh>` — renders the vocabulary table; calls `onRefresh()` after a deletion
@@ -62,6 +66,12 @@ A Next.js 16 single-page application that provides the user interface for Vademe
 - **Backend persistence logic** — handled entirely by the FastAPI backend and PostgreSQL
 
 ## Changelog
+
+### 2026-05-23 (v0.4.1)
+
+- Added `AreaToggle.tsx`: pill-style toggle switching between Vocabulary and Learning areas, styled with the `forest-*` palette.
+- Added `SensesTable.tsx`: Learning Area table fetching all senses via `getSenses()`, computing To Review badges via `toReview()`, managing local multi-select state, and triggering review sessions via `onStartReview`.
+- Updated `page.tsx`: added `area` (`"vocabulary" | "learning" | "review"`) and `reviewQueue` state; `SearchBar` now renders only in Vocabulary Area; `AreaToggle` renders above the content pane (hidden in Review Area); content pane conditionally renders `WordTable`, `SensesTable`, or a Review Area placeholder.
 
 ### 2026-05-23 (v0.4.0)
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,10 +1,12 @@
 "use client"; // The page uses React hooks (UseState and UseEffect) -> User Component
 
 import AddWordModal from "@/components/AddWordModal";
+import AreaToggle from "@/components/AreaToggle";
 import SearchBar from "@/components/SearchBar";
+import SensesTable from "@/components/SensesTable";
 import ThemeToggle from "@/components/ThemeToggle";
 import WordTable from "@/components/WordTable";
-import { Word } from "@/types/word";
+import { SenseWithWord, Word } from "@/types/word";
 import { useCallback, useEffect, useState } from "react";
 
 export default function Home() {
@@ -13,7 +15,13 @@ export default function Home() {
   const [loading, setLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState("");
 
-  // 2. Data Fetching: Request words from the FastAPI backend service, including search
+  // 2. Area State Management: 'area' controls the active view, 'reviewQueue' holds senses selected for review
+  const [area, setArea] = useState<"vocabulary" | "learning" | "review">(
+    "vocabulary",
+  );
+  const [reviewQueue, setReviewQueue] = useState<SenseWithWord[]>([]);
+
+  // 3. Data Fetching: Request words from the FastAPI backend service, including search
   const fetchWords = useCallback(async (searchQuery: string = "") => {
     try {
       setLoading(true);
@@ -33,10 +41,16 @@ export default function Home() {
     }
   }, []);
 
-  // 3. Effect Hook: Trigger fetch whenever searchTerm changes (already debounced by component)
+  // 4. Effect Hook: Trigger fetch whenever searchTerm changes (already debounced by component)
   useEffect(() => {
     fetchWords(searchTerm);
   }, [searchTerm, fetchWords]);
+
+  // 5. Review Handler: sets the review queue and transitions to the Review Area
+  function handleStartReview(selected: SenseWithWord[]): void {
+    setReviewQueue(selected);
+    setArea("review");
+  }
 
   return (
     <main className="min-h-screen bg-forest-50 dark:bg-forest-900 p-8">
@@ -94,30 +108,58 @@ export default function Home() {
           </div>
         </div>
 
-        {/* Integrated Search Bar */}
-        <div className="mb-6">
-          <SearchBar
-            onSearch={setSearchTerm}
-            placeholder="Search by word or translation..."
-          />
-        </div>
+        {/* Search Bar — Vocabulary Area only */}
+        {area === "vocabulary" && (
+          <div className="mb-6">
+            <SearchBar
+              onSearch={setSearchTerm}
+              placeholder="Search by word or translation..."
+            />
+          </div>
+        )}
+
+        {/* Area Toggle — hidden in Review Area */}
+        {area !== "review" && (
+          <div className="mb-4">
+            <AreaToggle
+              area={area}
+              onAreaChange={(newArea) => setArea(newArea)}
+            />
+          </div>
+        )}
 
         {/* Content Section */}
-        <div className="bg-white dark:bg-forest-800 rounded-xl shadow-sm border border-forest-200 dark:border-forest-700 p-6">
-          {loading ? (
-            <p className="text-center py-10 text-forest-600 dark:text-forest-300">
-              Loading your vocabulary...
-            </p>
-          ) : words.length === 0 ? (
+        {area === "vocabulary" && (
+          <div className="bg-white dark:bg-forest-800 rounded-xl shadow-sm border border-forest-200 dark:border-forest-700 p-6">
+            {loading ? (
+              <p className="text-center py-10 text-forest-600 dark:text-forest-300">
+                Loading your vocabulary...
+              </p>
+            ) : words.length === 0 ? (
+              <p className="text-center py-10 text-forest-600 dark:text-forest-300 italic">
+                No words found. Time to add your first one!
+              </p>
+            ) : (
+              <div className="overflow-x-auto">
+                <WordTable words={words} onRefresh={fetchWords} />
+              </div>
+            )}
+          </div>
+        )}
+
+        {area === "learning" && (
+          <div className="bg-white dark:bg-forest-800 rounded-xl shadow-sm border border-forest-200 dark:border-forest-700 p-6">
+            <SensesTable onStartReview={handleStartReview} />
+          </div>
+        )}
+
+        {area === "review" && (
+          <div className="bg-white dark:bg-forest-800 rounded-xl shadow-sm border border-forest-200 dark:border-forest-700 p-6">
             <p className="text-center py-10 text-forest-600 dark:text-forest-300 italic">
-              No words found. Time to add your first one!
+              Review Area coming soon ({reviewQueue.length} senses queued).
             </p>
-          ) : (
-            <div className="overflow-x-auto">
-              <WordTable words={words} onRefresh={fetchWords} />
-            </div>
-          )}
-        </div>
+          </div>
+        )}
       </div>
     </main>
   );

--- a/frontend/src/components/AreaToggle.tsx
+++ b/frontend/src/components/AreaToggle.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+type Area = "vocabulary" | "learning";
+
+interface AreaToggleProps {
+  area: Area;
+  onAreaChange: (area: Area) => void;
+}
+
+export default function AreaToggle({ area, onAreaChange }: AreaToggleProps) {
+  return (
+    <div className="flex items-center gap-1 p-1 rounded-lg bg-forest-100 dark:bg-forest-800 w-fit">
+      <button
+        onClick={() => onAreaChange("vocabulary")}
+        className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
+          area === "vocabulary"
+            ? "bg-white dark:bg-forest-700 text-forest-900 dark:text-forest-50 shadow-sm"
+            : "text-forest-600 dark:text-forest-300 hover:text-forest-900 dark:hover:text-forest-100"
+        }`}
+      >
+        Vocabulary
+      </button>
+      <button
+        onClick={() => onAreaChange("learning")}
+        className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
+          area === "learning"
+            ? "bg-white dark:bg-forest-700 text-forest-900 dark:text-forest-50 shadow-sm"
+            : "text-forest-600 dark:text-forest-300 hover:text-forest-900 dark:hover:text-forest-100"
+        }`}
+      >
+        Learning
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/SensesTable.tsx
+++ b/frontend/src/components/SensesTable.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { getSenses } from "@/lib/api";
+import { toReview } from "@/lib/reviewUtils";
+import { SenseWithWord } from "@/types/word";
+import { BookMarked } from "lucide-react";
+import { useEffect, useState } from "react";
+
+interface SensesTableProps {
+  onStartReview: (selected: SenseWithWord[]) => void;
+}
+
+export default function SensesTable({ onStartReview }: SensesTableProps) {
+  const [senses, setSenses] = useState<SenseWithWord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selectedSenseIds, setSelectedSenseIds] = useState<Set<number>>(
+    new Set(),
+  );
+
+  useEffect(() => {
+    getSenses()
+      .then(setSenses)
+      .catch((err) => console.error("Error fetching senses:", err))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const toggleSelect = (id: number) => {
+    setSelectedSenseIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  };
+
+  const handleStartReview = () => {
+    const selected = senses.filter((s) => selectedSenseIds.has(s.id!));
+    onStartReview(selected);
+  };
+
+  if (loading) {
+    return (
+      <p className="text-center py-10 text-forest-600 dark:text-forest-300">
+        Loading senses...
+      </p>
+    );
+  }
+
+  if (senses.length === 0) {
+    return (
+      <p className="text-center py-10 text-forest-600 dark:text-forest-300 italic">
+        No senses found. Add words with senses first.
+      </p>
+    );
+  }
+
+  return (
+    <div>
+      <div className="overflow-hidden shadow ring-1 ring-forest-900/10 dark:ring-forest-100/10 sm:rounded-lg">
+        <table className="min-w-full divide-y divide-forest-200 dark:divide-forest-700">
+          <thead className="bg-forest-50 dark:bg-forest-800">
+            <tr>
+              <th className="py-3.5 pl-4 pr-3 w-10" />
+              <th className="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-forest-900 dark:text-forest-100">
+                Word
+              </th>
+              <th className="px-3 py-3.5 text-left text-sm font-semibold text-forest-900 dark:text-forest-100">
+                Translation
+              </th>
+              <th className="px-3 py-3.5 text-left text-sm font-semibold text-forest-900 dark:text-forest-100">
+                Category
+              </th>
+              <th className="px-3 py-3.5 text-left text-sm font-semibold text-forest-900 dark:text-forest-100">
+                Difficulty
+              </th>
+              <th className="px-3 py-3.5 text-left text-sm font-semibold text-forest-900 dark:text-forest-100">
+                Last Reviewed
+              </th>
+              <th className="px-3 py-3.5 text-left text-sm font-semibold text-forest-900 dark:text-forest-100">
+                To Review
+              </th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-forest-100 dark:divide-forest-700 bg-white dark:bg-forest-900">
+            {senses.map((sense) => {
+              const id = sense.id!;
+              const isSelected = selectedSenseIds.has(id);
+              const needsReview = toReview(sense);
+              const difficulty = sense.difficulty_level ?? "Medium";
+              const lastReviewed = sense.last_reviewed_at
+                ? new Date(sense.last_reviewed_at).toLocaleDateString()
+                : "Never";
+
+              return (
+                <tr
+                  key={id}
+                  onClick={() => toggleSelect(id)}
+                  className={`cursor-pointer transition-colors ${
+                    isSelected
+                      ? "bg-forest-50 dark:bg-forest-800/60"
+                      : "hover:bg-forest-50 dark:hover:bg-forest-800"
+                  }`}
+                >
+                  <td className="pl-4 pr-3 py-3">
+                    <input
+                      type="checkbox"
+                      checked={isSelected}
+                      onChange={() => toggleSelect(id)}
+                      onClick={(e) => e.stopPropagation()}
+                      className="h-4 w-4 rounded border-forest-300 text-forest-600 focus:ring-forest-500"
+                    />
+                  </td>
+                  <td className="whitespace-nowrap py-3 pl-4 pr-3 text-sm font-bold text-forest-700 dark:text-forest-200">
+                    {sense.word}
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-3 text-sm text-forest-600 dark:text-forest-200">
+                    {sense.translation}
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-3 text-sm">
+                    <span className="inline-flex items-center rounded-md bg-forest-50 dark:bg-forest-700 px-2 py-1 text-xs font-medium text-forest-700 dark:text-forest-100 ring-1 ring-inset ring-forest-700/10 dark:ring-forest-300/20">
+                      {sense.category ?? "N/A"}
+                    </span>
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-3 text-sm text-forest-600 dark:text-forest-200">
+                    {difficulty}
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-3 text-sm text-forest-400 dark:text-forest-400">
+                    {lastReviewed}
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-3 text-sm">
+                    {needsReview && (
+                      <span className="inline-flex items-center gap-1 rounded-md bg-amber-50 dark:bg-amber-900/30 px-2 py-1 text-xs font-medium text-amber-700 dark:text-amber-300 ring-1 ring-inset ring-amber-600/20">
+                        <BookMarked className="w-3 h-3" />
+                        Review
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {selectedSenseIds.size > 0 && (
+        <div className="mt-4 flex justify-end">
+          <button
+            onClick={handleStartReview}
+            className="px-4 py-2 rounded-lg bg-forest-700 hover:bg-forest-800 dark:bg-forest-600 dark:hover:bg-forest-500 text-white text-sm font-medium transition-colors"
+          >
+            Start Review ({selectedSenseIds.size})
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

The PR resolves the issue #56  by adding the Learning Area to the UI.

## Changelog

### Added

- **Frontend**: New `AreaToggle` React component — pill-style toggle switch between Vocabulary and Learning areas, styled with the `forest-*` Tailwind palette; hidden when the Review Area is active.
- **Frontend**: New `SensesTable` React component — Learning Area table that fetches all senses from `GET /senses/`, renders To Review badges via `toReview()`, supports multi-select checkboxes with local state, and triggers the review session via `onStartReview`.

### Changed

- **Frontend**: `page.tsx` extended with `area` (`"vocabulary" | "learning" | "review"`) and `reviewQueue: SenseWithWord[]` state; `SearchBar` rendered only in Vocabulary Area; `AreaToggle` rendered above the content pane (hidden when `area === "review"`); content pane now conditionally renders `WordTable`, `SensesTable`, or a Review Area placeholder based on `area`.

## Checklist

### Mandatory

- [x] The title of the Pull Request starts with the JIRA ticket number (if provided)
- [x] The title of the Pull Request must reflect the corresponding issue title
- [x] It has to have a `Description` section, specifying which is the `#issue` it's resolving and how
- [x] It has to have a `Changelog` section, reporting what has been changed in the corresponding issue
- [x] The project version must have been updated

### Optional

- [x] Update the Wiki
- [x] Update the `README.md`
- [x] Update the `CHANGELOG.md`
