### PR TITLE
Feat/58 Review workflow

### DIFF
--- a/.claude/planning/5-review-feature/58-review-workflow.md
+++ b/.claude/planning/5-review-feature/58-review-workflow.md
@@ -1,0 +1,169 @@
+# #58: Review Workflow — Transitions, API Updates, and Completion Screen
+
+**GitHub Issue:** [#58 — Review Workflow](https://github.com/Volscente/vademecum-germanicum/issues/58)
+**GitHub Milestone:** [Milestone: 5-review-feature](https://github.com/Volscente/vademecum-germanicum/milestone/7)
+**Notion page:** [5 - Review Feature](https://www.notion.so/5-Review-Feature-3575cc6c0f0780c6a2beeedca2095b11)
+
+---
+
+## Technical Scope
+
+**In scope:**
+
+- `frontend/src/components/ReviewArea.tsx` — Add `currentIndex` and `isTransitioning` state; destructure `onNavigate` (declared in interface but currently not in the function signature); wire `onDifficultySelect` to `updateSenseReview` + index advancement; apply opacity + `translate-x` CSS transition on the `SenseCard` wrapper; render `ReviewCompleteScreen` when the queue is exhausted; update progress counter to reflect `currentIndex + 1`
+- `frontend/src/components/ReviewCompleteScreen.tsx` — New completion screen with "Return to Vocabulary Area" and "Return to Learning Area" navigation buttons
+
+**Out of scope:**
+
+- Cart persistence across browser refresh — accepted v1 limitation; no `localStorage` integration
+- Error handling or retry logic for `updateSenseReview` failures — fire-and-forget is intentional
+- Any backend changes — all API work was completed in TASK-1
+- Any changes to `page.tsx`, `SenseCard.tsx`, or `api.ts` — all wiring above those layers is already correct
+
+---
+
+## Architecture
+
+```txt
+User clicks Difficulty Button
+          │  onDifficultySelect(level)
+          ▼
+  handleDifficultySelect(level)   [ReviewArea.tsx]
+          │
+          ├── updateSenseReview(sense.id, level)  ── fire-and-forget PUT /senses/{id}/review
+          │
+          ├── setIsTransitioning(true)
+          │       CSS wrapper: opacity-0 + translate-x-4
+          │
+          └── setTimeout(~150 ms)
+                    │
+                    ├── setIsTransitioning(false)
+                    └── setCurrentIndex(prev => prev + 1)
+                              │
+                              ├── currentIndex < reviewQueue.length
+                              │     → SenseCard for reviewQueue[currentIndex]
+                              │       CSS wrapper: opacity-100 + translate-x-0
+                              │
+                              └── currentIndex === reviewQueue.length
+                                    → ReviewCompleteScreen
+                                          │
+                                          ├── "Return to Vocabulary" → onNavigate("vocabulary")
+                                          └── "Return to Learning"   → onNavigate("learning")
+```
+
+### Fire-and-forget update rationale
+
+`updateSenseReview` is called without `await`. The card advances immediately, preserving the rapid flashcard rhythm. A network failure silently loses the rating for that card; accepted for v1 given the low-stakes consequence (the user can re-review the sense on the next session).
+
+---
+
+## Tech Stack
+
+No new packages required.
+
+---
+
+## Implementation Details
+
+### Modules / Files
+
+| File | Action | Description |
+|------|--------|-------------|
+| `frontend/src/components/ReviewArea.tsx` | Update | Add `currentIndex` + `isTransitioning` state; destructure `onNavigate`; wire difficulty handler; animate card wrapper; render `ReviewCompleteScreen` on exhaustion; update progress counter |
+| `frontend/src/components/ReviewCompleteScreen.tsx` | Create | Completion screen with two `onNavigate` buttons, styled with `forest-*` palette |
+
+---
+
+### Key Functions
+
+**`handleDifficultySelect` in `ReviewArea.tsx`**
+
+```typescript
+function handleDifficultySelect(level: "Easy" | "Medium" | "Hard" | "VeryHard"): void
+```
+
+Fires the review update, triggers the CSS exit animation, and schedules the card advance.
+
+- Calls `updateSenseReview(reviewQueue[currentIndex].id, level)` without `await` (fire-and-forget)
+- Sets `isTransitioning = true` — the `SenseCard` wrapper gains `opacity-0 translate-x-4`
+- Schedules `setTimeout(() => { setIsTransitioning(false); setCurrentIndex(i => i + 1); }, 150)`
+
+**Render branching in `ReviewArea.tsx`**
+
+```typescript
+if (currentIndex >= reviewQueue.length) {
+  return <ReviewCompleteScreen onNavigate={onNavigate} />;
+}
+```
+
+Otherwise renders:
+
+```tsx
+<div className={clsx(
+  "transition-all duration-150",
+  isTransitioning ? "opacity-0 translate-x-4" : "opacity-100 translate-x-0"
+)}>
+  <SenseCard
+    sense={reviewQueue[currentIndex]}
+    onDifficultySelect={handleDifficultySelect}
+  />
+</div>
+```
+
+Progress counter changes from the hardcoded `1` to `{currentIndex + 1}`:
+
+```tsx
+<p className="mb-4 text-sm text-forest-500 dark:text-forest-400 text-right">
+  {currentIndex + 1} / {reviewQueue.length} senses
+</p>
+```
+
+**`ReviewCompleteScreen` component**
+
+```tsx
+interface ReviewCompleteScreenProps {
+  onNavigate: (area: "vocabulary" | "learning") => void;
+}
+```
+
+Renders a centred card (consistent with the `bg-white dark:bg-forest-800 rounded-xl shadow-sm border` pattern) with:
+
+- A completion heading
+- "Return to Vocabulary Area" button → calls `onNavigate("vocabulary")`
+- "Return to Learning Area" button → calls `onNavigate("learning")`
+
+Both buttons follow the existing `forest-*` palette button style used throughout the app.
+
+---
+
+### Data Models / Schemas
+
+No new data models. `SenseWithWord` and `Sense` types from `frontend/src/types/word.ts` are reused as-is.
+
+---
+
+### Testing Strategy
+
+**Manual integration test (golden path):**
+
+1. Run `just dev`
+2. Navigate to Learning Area, select ≥ 2 senses, click "Start Review"
+3. On each card, click any Difficulty Level button and verify:
+   - Card fades out and slides right (opacity + translate-x transition, ~150 ms)
+   - Next card appears; progress counter increments (e.g. "2 / 3 senses")
+4. On the final card, click any Difficulty Level button → `ReviewCompleteScreen` renders
+5. Click "Return to Vocabulary Area" → `WordTable` renders, `AreaToggle` reappears
+6. Repeat steps 2–4, click "Return to Learning Area" → `SensesTable` renders
+
+**Edge cases:**
+
+- Single-sense queue: after the only card is rated, completion screen renders immediately
+- Empty queue (`reviewQueue.length === 0`): existing empty-state fallback in `ReviewArea` must remain unchanged — ensure the `if (reviewQueue.length === 0)` guard stays above the `currentIndex >= reviewQueue.length` check
+- Rapid clicking: multiple clicks before the 150 ms animation completes will stack `setCurrentIndex` updates via the functional updater form (`prev => prev + 1`), which is safe — verify the counter does not over-run past `reviewQueue.length`
+
+---
+
+### Open Questions / Risks
+
+- [x] **Fire-and-forget failure visibility:** If `updateSenseReview` rejects, the user's rating is lost silently. Acceptable for v1; surface as a named future enhancement alongside cart persistence. **Target:** post-v1. **Answer:** Acceptable for v1.
+- [x] **Rapid-click stacking:** Difficulty buttons remain enabled during `isTransitioning`. If rapid clicking causes `currentIndex` to exceed `reviewQueue.length`, the `>=` guard handles it safely, but the UX may feel glitchy. Consider disabling buttons while `isTransitioning === true` if observed during manual testing. **Target:** validate in step 3 of the manual test above. **Answer:** Validation through user acceptance tests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2026-05-23
+
+### Added
+
+- **Frontend**: New `ReviewCompleteScreen` React component — session-end screen with "Return to Vocabulary Area" and "Return to Learning Area" navigation buttons.
+
+### Changed
+
+- **Frontend**: `ReviewArea` updated with `currentIndex` and `isTransitioning` state to drive card progression; `onDifficultySelect` now calls `updateSenseReview` (fire-and-forget) and advances the card after a 150 ms opacity + `translate-x` CSS transition; progress counter reflects the current card index; `ReviewCompleteScreen` is rendered when the queue is exhausted; `onNavigate` prop is now consumed (was declared but unused).
+
 ## [0.4.2] - 2026-05-23
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "backend"
-version = "0.4.2"
+version = "0.4.3"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Simone Porreca", email = "porrecasimone@gmail.com" }]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -9,7 +9,8 @@ A Next.js 16 single-page application that provides the user interface for Vademe
 - **`src/app/page.tsx`** — Root page; owns all state (words list, search term, loading flag, active area, review queue), fetches from the backend, and passes handlers down to child components
 - **`src/components/AreaToggle.tsx`** — Pill-style toggle switch between the Vocabulary Area and the Learning Area; hidden when the Review Area is active
 - **`src/components/SensesTable.tsx`** — Senses table for the Learning Area; fetches all senses via `getSenses()`, renders per-row To Review badges via `toReview()`, maintains local multi-select state, and fires `onStartReview` with the selected senses
-- **`src/components/ReviewArea.tsx`** — Full-canvas review session container; renders `SenseCard` for the current sense in the queue; displays a read-only "1 / N senses" progress counter; shows an empty-queue fallback
+- **`src/components/ReviewArea.tsx`** — Full-canvas review session container; owns `currentIndex` and `isTransitioning` state; fires `updateSenseReview` on difficulty selection then advances the card with a 150 ms opacity + `translate-x` CSS transition; renders `ReviewCompleteScreen` when the queue is exhausted; shows an empty-queue fallback
+- **`src/components/ReviewCompleteScreen.tsx`** — Session-end screen rendered when all cards in the review queue have been rated; two buttons to navigate back to the Vocabulary Area or Learning Area via `onNavigate`
 - **`src/components/SenseCard.tsx`** — Flashcard display for a single sense; three collapsible sections (Word Information, Verb Morphology, Sense Information); Verb Morphology rendered only when `category === "verb"`; four Difficulty Level buttons (Easy / Medium / Hard / Very Hard)
 - **`src/components/AddWordModal.tsx`** — Modal form for creating a new word entry; includes an "Enrich" button that calls the AI enrichment API to pre-populate fields
 - **`src/components/EditWordModal.tsx`** — Full edit form for updating word data (all fields including nested senses) with a delete action; opened by clicking a row in WordTable
@@ -24,7 +25,8 @@ A Next.js 16 single-page application that provides the user interface for Vademe
 
 ## Public interfaces
 
-- `<ReviewArea reviewQueue onNavigate>` — review session container; `reviewQueue: SenseWithWord[]`, `onNavigate: (area: "vocabulary" | "learning") => void`
+- `<ReviewArea reviewQueue onNavigate>` — review session container; `reviewQueue: SenseWithWord[]`, `onNavigate: (area: "vocabulary" | "learning") => void`; manages card progression and transition animation internally
+- `<ReviewCompleteScreen onNavigate>` — completion screen; `onNavigate: (area: "vocabulary" | "learning") => void`; rendered by `ReviewArea` after the last card is rated
 - `<SenseCard sense onDifficultySelect>` — sense flashcard; `onDifficultySelect: (level: "Easy" | "Medium" | "Hard" | "VeryHard") => void`
 - `<AreaToggle area onAreaChange>` — pill toggle between `"vocabulary"` and `"learning"`; not rendered when `area === "review"`
 - `<SensesTable onStartReview>` — senses table with multi-select checkboxes and "Start Review" button; calls `onStartReview(selected: SenseWithWord[])` to hand off the review queue
@@ -70,6 +72,11 @@ A Next.js 16 single-page application that provides the user interface for Vademe
 - **Backend persistence logic** — handled entirely by the FastAPI backend and PostgreSQL
 
 ## Changelog
+
+### 2026-05-23 (v0.4.3)
+
+- Added `ReviewCompleteScreen.tsx`: session-end screen with "Return to Vocabulary Area" and "Return to Learning Area" buttons wired to `onNavigate`.
+- Updated `ReviewArea.tsx`: added `currentIndex` and `isTransitioning` state; wired `onDifficultySelect` to `updateSenseReview` (fire-and-forget) + 150 ms opacity/`translate-x` transition; progress counter now reflects `currentIndex + 1`; renders `ReviewCompleteScreen` when `currentIndex >= reviewQueue.length`; `onNavigate` is now destructured and used.
 
 ### 2026-05-23 (v0.4.2)
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/components/ReviewArea.tsx
+++ b/frontend/src/components/ReviewArea.tsx
@@ -1,14 +1,21 @@
 "use client";
 
+import ReviewCompleteScreen from "@/components/ReviewCompleteScreen";
 import SenseCard from "@/components/SenseCard";
+import { updateSenseReview } from "@/lib/api";
 import { SenseWithWord } from "@/types/word";
+import { clsx } from "clsx";
+import { useState } from "react";
 
 interface ReviewAreaProps {
   reviewQueue: SenseWithWord[];
   onNavigate: (area: "vocabulary" | "learning") => void;
 }
 
-export default function ReviewArea({ reviewQueue }: ReviewAreaProps) {
+export default function ReviewArea({ reviewQueue, onNavigate }: ReviewAreaProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isTransitioning, setIsTransitioning] = useState(false);
+
   if (reviewQueue.length === 0) {
     return (
       <div className="bg-white dark:bg-forest-800 rounded-xl shadow-sm border border-forest-200 dark:border-forest-700 p-6">
@@ -19,14 +26,32 @@ export default function ReviewArea({ reviewQueue }: ReviewAreaProps) {
     );
   }
 
-  const sense = reviewQueue[0];
+  if (currentIndex >= reviewQueue.length) {
+    return <ReviewCompleteScreen onNavigate={onNavigate} />;
+  }
+
+  function handleDifficultySelect(level: "Easy" | "Medium" | "Hard" | "VeryHard"): void {
+    void updateSenseReview(reviewQueue[currentIndex].id, level);
+    setIsTransitioning(true);
+    setTimeout(() => {
+      setIsTransitioning(false);
+      setCurrentIndex((prev) => prev + 1);
+    }, 150);
+  }
 
   return (
     <div>
       <p className="mb-4 text-sm text-forest-500 dark:text-forest-400 text-right">
-        1 / {reviewQueue.length} senses
+        {currentIndex + 1} / {reviewQueue.length} senses
       </p>
-      <SenseCard sense={sense} onDifficultySelect={() => {}} />
+      <div
+        className={clsx(
+          "transition-all duration-150",
+          isTransitioning ? "opacity-0 translate-x-4" : "opacity-100 translate-x-0",
+        )}
+      >
+        <SenseCard sense={reviewQueue[currentIndex]} onDifficultySelect={handleDifficultySelect} />
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/ReviewCompleteScreen.tsx
+++ b/frontend/src/components/ReviewCompleteScreen.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+interface ReviewCompleteScreenProps {
+  onNavigate: (area: "vocabulary" | "learning") => void;
+}
+
+export default function ReviewCompleteScreen({ onNavigate }: ReviewCompleteScreenProps) {
+  return (
+    <div className="bg-white dark:bg-forest-800 rounded-xl shadow-sm border border-forest-200 dark:border-forest-700 p-6 text-center">
+      <h2 className="text-xl font-semibold text-forest-900 dark:text-forest-50 mb-2">
+        Review Complete
+      </h2>
+      <p className="text-sm text-forest-600 dark:text-forest-300 mb-8">
+        All senses in your queue have been reviewed.
+      </p>
+      <div className="flex justify-center gap-3">
+        <button
+          type="button"
+          onClick={() => onNavigate("vocabulary")}
+          className="px-4 py-2 rounded-lg text-sm font-medium bg-forest-100 hover:bg-forest-200 dark:bg-forest-700/50 dark:hover:bg-forest-700 text-forest-700 dark:text-forest-200 transition-colors"
+        >
+          Return to Vocabulary Area
+        </button>
+        <button
+          type="button"
+          onClick={() => onNavigate("learning")}
+          className="px-4 py-2 rounded-lg text-sm font-medium bg-forest-100 hover:bg-forest-200 dark:bg-forest-700/50 dark:hover:bg-forest-700 text-forest-700 dark:text-forest-200 transition-colors"
+        >
+          Return to Learning Area
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vademecum-germanicum"
-version = "0.4.2"
+version = "0.4.3"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Description

The PR resolves the issue #58 by adding the Review Workflow.

## Changelog

### Added

- **Frontend**: New `ReviewCompleteScreen` React component — session-end screen with "Return to Vocabulary Area" and "Return to Learning Area" navigation buttons.

### Changed

- **Frontend**: `ReviewArea` updated with `currentIndex` and `isTransitioning` state to drive card progression; `onDifficultySelect` now calls `updateSenseReview` (fire-and-forget) and advances the card after a 150 ms opacity + `translate-x` CSS transition; progress counter reflects the current card index; `ReviewCompleteScreen` is rendered when the queue is exhausted; `onNavigate` prop is now consumed (was declared but unused).

## Checklist

### Mandatory

- [x] The title of the Pull Request starts with the JIRA ticket number (if provided)
- [x] The title of the Pull Request must reflect the corresponding issue title
- [x] It has to have a `Description` section, specifying which is the `#issue` it's resolving and how
- [x] It has to have a `Changelog` section, reporting what has been changed in the corresponding issue
- [x] The project version must have been updated

### Optional

- [x] Update the Wiki
- [x] Update the `README.md`
- [x] Update the `CHANGELOG.md`
