### PR TITLE
Fix/64 Hotfix change test database

### DIFF
--- a/.claude/hotfix/64-hotfix-change-test-database/hotfix-description.md
+++ b/.claude/hotfix/64-hotfix-change-test-database/hotfix-description.md
@@ -1,0 +1,60 @@
+---
+title: "Unit tests write to the production database"
+project: "vademecum-germanicum"
+author: "Simone Porreca"
+severity: "high"
+affected-versions:
+  - "current"
+environments:
+  - "local development"
+tech-stack:
+  - "Python"
+  - "FastAPI"
+  - "PostgreSQL"
+  - "SQLAlchemy"
+  - "pytest"
+context-paths:
+  - "backend/tests/fixtures/database_management.py"
+  - "backend/src/backend/database.py"
+  - "backend/src/backend/main.py"
+  - "docker-compose.yml"
+  - "backend/README.md"
+---
+
+## Symptom
+
+Unit tests executed via `just run_tests` write data to the production PostgreSQL database (`vademecum_db`). After a test run, records created by the tests persist in the production database instead of being discarded.
+
+## Root cause
+
+The `db_session` fixture in `database_management.py` opens a `SessionLocal` connection and rolls it back after each test. However, it never overrides the `get_db` dependency in the FastAPI app. The `TestClient` therefore uses the real `get_db` function for every HTTP request, which opens its own independent session against `DATABASE_URL` (the production database). The rollback in `db_session` only affects the direct `connection` object in the fixture, not the sessions created by `get_db` during test execution — so all writes committed through the TestClient are permanent.
+
+## Fix approach
+
+Override the `get_db` FastAPI dependency in the test fixtures to inject the transactional session that gets rolled back. The `db_session` fixture should yield a session that is both:
+
+1. Used directly by any test that needs it.
+2. Injected into the FastAPI app via `app.dependency_overrides[get_db]` so that TestClient HTTP requests also use the same rolled-back session.
+
+The override must be cleaned up after each test to avoid leaking state between tests.
+
+## Verification steps
+
+1. Run `just run_tests` — all existing tests must pass.
+2. Connect to the production database after the test run and confirm no test data was persisted (e.g. `SELECT * FROM word;` returns only pre-existing rows, none added by tests).
+
+## Scope
+
+**In scope:**
+
+- Fix `backend/tests/fixtures/database_management.py` to override the `get_db` dependency so all test HTTP requests are routed through the rolled-back session.
+
+**Out of scope:**
+
+- Refactoring production database code: separate initiative.
+- Adding a dedicated test database container: out of scope for this hotfix; the rollback approach is sufficient.
+
+## Known risks
+
+- Tests that currently assert side effects via the direct `connection` object may behave differently once the TestClient shares the same session; review test assertions after the fix.
+- If any test spawns background tasks that open their own DB sessions outside of FastAPI's DI, those sessions will not be captured by the override and would still hit the production database.

--- a/.claude/hotfix/64-hotfix-change-test-database/hotfix-tech-spec.md
+++ b/.claude/hotfix/64-hotfix-change-test-database/hotfix-tech-spec.md
@@ -1,0 +1,143 @@
+# [HOTFIX] Unit tests write to the production database
+
+**Severity:** high
+**Affected versions:** current
+**Environments:** local development
+**Tech stack:** Python, FastAPI, PostgreSQL, SQLAlchemy, pytest
+
+---
+
+## Symptom
+
+Unit tests executed via `just run_tests` write data to the production PostgreSQL database (`vademecum_db`). After a test run, records created by the tests persist in the production database instead of being discarded.
+
+---
+
+## Root Cause Analysis
+
+The `db_session` fixture in `database_management.py` opens a `SessionLocal` connection and registers a transaction for rollback. However, it never overrides the FastAPI `get_db` dependency. Because of this, HTTP requests made through `TestClient` call the real `get_db`, which opens its own independent `SessionLocal` session bound directly to `DATABASE_URL`. Writes in those sessions are committed permanently and are invisible to the fixture's rollback.
+
+```
+Test function
+│
+├── db_session fixture
+│   └── SessionLocal() ──► BEGIN / ROLLBACK   ← only this session is rolled back
+│
+└── TestClient(app)
+    └── HTTP request → FastAPI → get_db()
+                                  └── SessionLocal() ──► COMMIT  ← escapes rollback
+                                                                      ↓
+                                                               vademecum_db (permanent)
+```
+
+The transaction rollback in `db_session` is therefore a no-op with respect to the data written through TestClient, because the two sessions are entirely independent connections to the database.
+
+---
+
+## Technical Scope
+
+**In scope:**
+
+- `backend/tests/fixtures/database_management.py` — fix the `db_session` fixture to override `get_db` and bind TestClient requests to the rolled-back session.
+
+**Out of scope:**
+
+- Refactoring production database code: separate initiative.
+- Adding a dedicated test database container: the rollback approach is sufficient.
+
+---
+
+## Implementation Details
+
+### Modules / Files
+
+| File | Action | Description |
+|------|--------|-------------|
+| `backend/tests/fixtures/database_management.py` | Modify | Override `get_db` in `db_session`; bind the test session to a connection-level transaction so that route `commit()` calls do not escape the rollback. |
+
+### Key Changes
+
+**`backend/tests/fixtures/database_management.py`**
+
+Replace the current `db_session` fixture with a version that:
+
+1. Opens a raw engine connection and begins an explicit outer transaction.
+2. Creates a new `Session` bound to that connection so all SQL runs over the same underlying connection.
+3. Overrides `app.dependency_overrides[get_db]` with a generator that yields the bound session — this ensures every FastAPI route that declares `db: Session = Depends(get_db)` receives the same session as the test.
+4. Rolls back the outer connection-level transaction in `finally`, which undoes all writes regardless of any `session.commit()` calls made by route handlers during the test.
+5. Clears the dependency override in `finally` to avoid state leakage between tests.
+
+```python
+"""
+Database management fixtures.
+"""
+
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
+from backend.database import engine, get_db
+from backend.main import app
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(scope="session")
+def client():
+    """Provides a single TestClient for the whole test session."""
+    return TestClient(app)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def db_session():
+    """
+    Open a connection-level transaction and inject it into the FastAPI app
+    via dependency_overrides so all writes — both direct and via TestClient
+    HTTP requests — are covered by the rollback.
+    """
+    connection = engine.connect()
+    transaction = connection.begin()
+    bound_session = sessionmaker(autocommit=False, autoflush=False, bind=connection)()
+
+    app.dependency_overrides[get_db] = lambda: iter([bound_session])
+
+    try:
+        yield bound_session
+    finally:
+        transaction.rollback()
+        bound_session.close()
+        connection.close()
+        app.dependency_overrides.pop(get_db, None)
+```
+
+**Why a connection-level transaction instead of `SessionLocal()`:**
+
+`SessionLocal()` wraps a connection with `autocommit=False`, meaning each `session.commit()` call inside a route handler commits directly to the database. Binding a new `Session` to a raw `connection` that already holds an outer `transaction` means route-handler commits flush data to the connection but cannot advance past the outer transaction — so `transaction.rollback()` always undoes everything.
+
+---
+
+## Verification
+
+### Manual checks
+
+1. Run the full test suite:
+   ```bash
+   just run_tests
+   ```
+   All tests must pass with exit code `0`.
+
+2. After the test run, connect to the production database and verify no test data was written:
+   ```bash
+   docker exec -it vademecum_db psql -U $POSTGRES_USER -d $POSTGRES_DB -c "SELECT COUNT(*) FROM word;"
+   ```
+   The row count must match the count before the test run.
+
+### Edge cases to validate
+
+- Tests that assert on data inserted earlier in the same test function — these rely on the bound session seeing its own uncommitted writes, which it will because both the test and the routes share the same session.
+- Tests that call multiple HTTP endpoints in sequence within one test function — each call reuses the same session via the override, so state is visible across calls within the test and rolled back at the end.
+
+---
+
+## Open Questions / Risks
+
+- [ ] **Session sharing changes assertion behaviour:** Tests that currently read back data through the direct `connection` object and data written via TestClient may now see it correctly for the first time. Review test assertions that previously relied on the two sessions being independent. **Target:** before merging
+- [ ] **Background tasks outside DI:** If any route spawns a background task that opens its own DB session (e.g. `BackgroundTasks` calling a function that constructs its own `SessionLocal()`), those sessions bypass the override and still hit the production database. Audit routes for background DB writes if tests reveal unexpected data after the fix. **Target:** TBD
+- [ ] **SQLAlchemy version compatibility:** The `Session(bind=connection)` / `sessionmaker(bind=connection)` pattern is deprecated in SQLAlchemy 2.x. If the project upgrades to 2.x, migrate to `Session(bind=connection)` → `with Session(connection) as session:` and the `connection.begin()` context manager pattern. **Target:** TBD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4] - 2026-05-24
+
+### Fixed
+
+- **Tests**: `db_session` fixture now overrides `app.dependency_overrides[get_db]` so TestClient HTTP requests use the same SQLAlchemy session as the test. A `begin_nested()` SAVEPOINT prevents route-level `commit()` calls from committing the outer transaction; an `after_transaction_end` event listener restarts the SAVEPOINT after each release. The outer transaction is rolled back in `finally`, ensuring no test data reaches the production database.
+
 ## [0.4.3] - 2026-05-23
 
 ### Added

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "backend"
-version = "0.4.3"
+version = "0.4.4"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Simone Porreca", email = "porrecasimone@gmail.com" }]

--- a/backend/tests/fixtures/database_management.py
+++ b/backend/tests/fixtures/database_management.py
@@ -3,7 +3,9 @@ Database management fixtures.
 """
 
 import pytest
-from backend.database import SessionLocal
+from sqlalchemy import event
+from sqlalchemy.orm import Session
+from backend.database import engine, get_db
 from backend.main import app
 from fastapi.testclient import TestClient
 
@@ -17,15 +19,33 @@ def client():
 @pytest.fixture(scope="function", autouse=True)
 def db_session():
     """
-    Simulate the function backend/src/backend/database.get_db
-    by opening a clear rollback connection to the database.
+    Open a raw connection-level transaction, bind a Session to it, and add a
+    SAVEPOINT so that route-level commit() calls only release the SAVEPOINT
+    (not the outer connection transaction). Override get_db so every FastAPI
+    route in TestClient uses this same session. In teardown, session.close()
+    followed by trans.rollback() sends a real ROLLBACK to PostgreSQL,
+    discarding all test writes.
     """
-    connection = SessionLocal()
-    # Start a transaction
-    transaction = connection.begin()
+    connection = engine.connect()
+    trans = connection.begin()
+    session = Session(bind=connection)
+    nested = session.begin_nested()
+
+    @event.listens_for(session, "after_transaction_end")
+    def restart_savepoint(sess, t):
+        nonlocal nested
+        if not nested.is_active:
+            nested = sess.begin_nested()
+
+    def override_get_db():
+        yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+
     try:
-        yield connection
+        yield session
     finally:
-        # Roll back everything done during the test
-        transaction.rollback()
+        app.dependency_overrides.pop(get_db, None)
+        session.close()
+        trans.rollback()
         connection.close()

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vademecum-germanicum"
-version = "0.4.3"
+version = "0.4.4"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Description

The PR resolves the issue #64 by preventing unit tests to write in production database.

## Changelog

### Fixed

- **Tests**: `db_session` fixture now overrides `app.dependency_overrides[get_db]` so TestClient HTTP requests use the same SQLAlchemy session as the test. A `begin_nested()` SAVEPOINT prevents route-level `commit()` calls from committing the outer transaction; an `after_transaction_end` event listener restarts the SAVEPOINT after each release. The outer transaction is rolled back in `finally`, ensuring no test data reaches the production database.

## Checklist

### Mandatory

- [x] The title of the Pull Request starts with the JIRA ticket number (if provided)
- [x] The title of the Pull Request must reflect the corresponding issue title
- [x] It has to have a `Description` section, specifying which is the `#issue` it's resolving and how
- [x] It has to have a `Changelog` section, reporting what has been changed in the corresponding issue
- [x] The project version must have been updated

### Optional

- [x] Update the Wiki
- [x] Update the `README.md`
- [x] Update the `CHANGELOG.md`
