### PR TITLE
Feat/77 nested field arrays

### DIFF
--- a/.claude/8-multiple-prepositions/77-nested-field-arrays.md
+++ b/.claude/8-multiple-prepositions/77-nested-field-arrays.md
@@ -1,0 +1,260 @@
+# #77: Nested Field Arrays
+
+**GitHub Issue:** [#77 — Nested Field Arrays](https://github.com/Volscente/vademecum-germanicum/issues/77)
+**GitHub Milestone:** [8-multiple-prepositions](https://github.com/Volscente/vademecum-germanicum/milestone/10)
+**Notion page:** [8-Multiple-Prepositions](https://www.notion.so/8-Multiple-Prepositions-3605cc6c0f0780af82dec212d9b61def)
+
+---
+
+## Technical Scope
+
+**In scope:**
+
+- `frontend/src/components/GrammarPatternFields.tsx` — new sub-component; owns the nested `useFieldArray` for grammar patterns per sense
+- `frontend/src/components/AddWordModal.tsx` — replace inline grammar-pattern `.map()` with `<GrammarPatternFields>`
+- `frontend/src/components/EditWordModal.tsx` — same `<GrammarPatternFields>` wire-up; add collapsible card wrapper for the Grammar Patterns section; add `grammarPatternsCollapsed: boolean[]` state
+
+**Out of scope:**
+
+- `frontend/src/lib/wordSchema.ts` — `grammar_patterns: z.array(grammarPatternSchema).min(1)` is already correct (confirmed in TASK-1); no changes
+- `frontend/src/types/word.ts` — `GrammarPattern[]` is already correctly typed on `Sense` and `WordEnrichment`; no changes
+- `frontend/src/components/SenseCard.tsx` — read-only flashcard; surfacing multiple grammar patterns there is deferred
+- Backend — no schema changes, no migrations, no new endpoints
+- Enrichment mapping (`onEnrich` / `onReEnrich`) — both already call `reset({ ..., senses: enriched.senses })` passing the full `Sense[]` array with all `grammar_patterns`; no truncation found (verified in TASK-3 audit pre-check)
+
+---
+
+## Architecture
+
+```txt
+AddWordModal                               EditWordModal
+      │                                          │
+      │  senseFields.map((field, sIdx))          │  senseFields.map((field, sIdx))
+      │          │                               │          │
+      │          │                               │          ├── [Collapsible sense card]
+      │          │                               │          │        │
+      │          │                               │          │        ├── Meaning Summary, Register
+      │          │                               │          │        │
+      │          │                               │          │        └── [Collapsible GP card]
+      │          │                               │          │                  │
+      │          └─► <GrammarPatternFields        │          └──────────────────►<GrammarPatternFields
+      │                senseIndex={sIdx}         │                               senseIndex={sIdx}
+      │                control={control}         │                               control={control}
+      │                errors={errors} />        │                               errors={errors} />
+      │                                          │
+      │                                          └── grammarPatternsCollapsed: boolean[]
+      │                                              synced via useEffect on senseFields.length
+      │
+GrammarPatternFields (sub-component — owns the nested field array)
+      │
+      ├── useFieldArray({ control, name: `senses.${senseIndex}.grammar_patterns` })
+      │
+      ├── fields.map((gpField, gpIdx) =>
+      │         ├── <input register(`senses.${sIdx}.grammar_patterns.${gpIdx}.preposition`)>
+      │         ├── <select register(`senses.${sIdx}.grammar_patterns.${gpIdx}.case`)>
+      │         └── Remove button (disabled when fields.length === 1)
+      │
+      └── Add Grammar Pattern → append({ preposition: null, case: "Akkusativ" })
+```
+
+### Why a dedicated sub-component is mandatory
+
+React Hook Form's `useFieldArray` must be called unconditionally from a component body. Calling it inside a `.map()` callback violates the Rules of Hooks and produces a runtime error. `GrammarPatternFields` is the only correct pattern for a nested field array inside a sense loop. Each instance is independent — its field array is keyed to its `senseIndex`, so index management is isolated per sense.
+
+---
+
+## Tech Stack
+
+No new packages required. `react-hook-form` `useFieldArray` and the existing Zod schemas cover the requirement.
+
+---
+
+## Implementation Details
+
+### Modules / Files
+
+| File                                                    | Action | Description                                                                              |
+| ------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------- |
+| `frontend/src/components/GrammarPatternFields.tsx`      | Create | Sub-component encapsulating the nested `useFieldArray` for grammar patterns per sense   |
+| `frontend/src/components/AddWordModal.tsx`              | Update | Replace inline grammar-pattern rows with `<GrammarPatternFields>`                        |
+| `frontend/src/components/EditWordModal.tsx`             | Update | Replace inline grammar-pattern rows with `<GrammarPatternFields>` + collapsible card    |
+
+---
+
+### Key Functions / Components
+
+```tsx
+// GrammarPatternFields.tsx
+
+interface GrammarPatternFieldsProps {
+  senseIndex: number;
+  control: Control<WordFormValues>;
+  errors: FieldErrors<WordFormValues>;
+}
+
+export default function GrammarPatternFields({
+  senseIndex,
+  control,
+  errors,
+}: GrammarPatternFieldsProps): JSX.Element
+```
+
+- Calls `useFieldArray({ control, name: \`senses.${senseIndex}.grammar_patterns\` })`.
+- Renders one row per `fields` entry: a preposition `<input>` (registered to `senses.${senseIndex}.grammar_patterns.${gpIdx}.preposition`) and a case `<select>` (registered to `senses.${senseIndex}.grammar_patterns.${gpIdx}.case`) sharing the same `register` call.
+- Renders a Remove `<Trash2>` button per row; disabled when `fields.length === 1`.
+- Renders an "Add Grammar Pattern" `<PlusCircle>` button that calls `append({ preposition: null, case: "Akkusativ" })`.
+- Displays per-row validation errors from `errors.senses?.[senseIndex]?.grammar_patterns?.[gpIdx]`.
+
+---
+
+### AddWordModal.tsx changes
+
+Replace the inline Grammar Patterns block (currently iterating over `watchedSenses[sIdx]?.grammar_patterns`) with:
+
+```tsx
+<GrammarPatternFields
+  senseIndex={sIdx}
+  control={control}
+  errors={errors}
+/>
+```
+
+`watchedSenses` remains needed for the Example Sentences section — do not remove the `watch("senses")` call.
+
+---
+
+### EditWordModal.tsx changes
+
+**1. `grammarPatternsCollapsed` state** — one boolean per sense; mirrors `sensesCollapsed`.
+
+```tsx
+const [grammarPatternsCollapsed, setGrammarPatternsCollapsed] = useState<boolean[]>([]);
+```
+
+**2. `useEffect` sync** — identical pattern to the existing `sensesCollapsed` sync; triggers on `senseFields.length` changes to handle append, remove, and Re-enrich reset:
+
+```tsx
+useEffect(() => {
+  setGrammarPatternsCollapsed((prev) => {
+    if (senseFields.length > prev.length) {
+      return [...prev, ...Array(senseFields.length - prev.length).fill(false)];
+    }
+    return prev.slice(0, senseFields.length);
+  });
+}, [senseFields.length]);
+```
+
+**3. `handleCollapseAll` extension** — add `setGrammarPatternsCollapsed((prev) => prev.map(() => true))` alongside the existing `sensesCollapsed` collapse.
+
+**4. Collapsible Grammar Patterns card** inside each sense's card body (replicating the Verb Morphology `max-h` toggle pattern):
+
+```tsx
+{/* Grammar Patterns */}
+<div className="border border-forest-200 dark:border-forest-600 rounded-lg p-3">
+  <button
+    type="button"
+    onClick={() =>
+      setGrammarPatternsCollapsed((prev) =>
+        prev.map((c, i) => (i === sIdx ? !c : c)),
+      )
+    }
+    className="flex w-full items-center gap-2"
+  >
+    {grammarPatternsCollapsed[sIdx] ? (
+      <ChevronDown className="w-3 h-3 text-forest-600 dark:text-forest-300" />
+    ) : (
+      <ChevronUp className="w-3 h-3 text-forest-600 dark:text-forest-300" />
+    )}
+    <span className="text-xs font-semibold text-forest-600 dark:text-forest-300 uppercase tracking-wide">
+      Grammar Patterns
+    </span>
+    {!!errors.senses?.[sIdx]?.grammar_patterns && grammarPatternsCollapsed[sIdx] && (
+      <span className="ml-auto h-2 w-2 rounded-full bg-red-500" aria-label="Contains errors" />
+    )}
+  </button>
+  <div
+    className={clsx(
+      "overflow-hidden transition-[max-height] duration-300",
+      grammarPatternsCollapsed[sIdx] ? "max-h-0" : "max-h-500",
+    )}
+  >
+    <div className="pt-2">
+      <GrammarPatternFields
+        senseIndex={sIdx}
+        control={control}
+        errors={errors}
+      />
+    </div>
+  </div>
+</div>
+```
+
+Replace the existing inline Grammar Patterns block (currently iterating over `watchedSenses[sIdx]?.grammar_patterns`) with the block above.
+
+---
+
+### Data Models / Schemas
+
+No new data models. The relevant types already exist:
+
+```ts
+// wordSchema.ts (no changes)
+grammar_patterns: z.array(grammarPatternSchema).min(1)  // inside senseSchema
+
+// word.ts (no changes)
+interface GrammarPattern {
+  id?: number;
+  preposition: string | null;
+  case: "Nominativ" | "Akkusativ" | "Dativ" | "Genitiv";
+}
+```
+
+The `Control<WordFormValues>` and `FieldErrors<WordFormValues>` types are inferred from `wordSchema` and `useForm` — no new type declarations required.
+
+---
+
+### Testing Strategy
+
+**Step 0 — Payload shape verification (nested path guard)**
+
+Before running any UI smoke test, after wiring `GrammarPatternFields` into both modals, perform this check first:
+
+1. Start the app (`just dev`).
+2. Open **Add Word Modal** → fill in a word manually → add two grammar-pattern rows per sense with distinct values.
+3. Open the browser Network tab (DevTools → Network → filter by `words`).
+4. Submit the form.
+5. Inspect the request payload: each sense object must carry `grammar_patterns` as an array of two objects, each with `preposition` and `case` fields populated. If `grammar_patterns` is missing, `undefined`, or contains only one entry, the `name` path in `useFieldArray` or `register` is wrong — fix before proceeding.
+
+This is a mandatory first check because an incorrect `name` path yields `undefined` silently with no runtime error.
+
+**Manual smoke test (golden path — Add Word Modal):**
+
+1. Open **Add Word Modal** → type a word → click **Enrich**.
+2. Verify multiple grammar-pattern rows are pre-populated per sense (if the LLM returns more than one).
+3. Add a second grammar pattern row via "Add Grammar Pattern" — verify a new row appears with default `preposition=null`, `case=Akkusativ`.
+4. Attempt to remove the last row — verify the Remove button is disabled.
+5. Remove a non-last row — verify the remaining rows preserve their values.
+6. Submit the word — confirm payload in Network tab: each sense carries `grammar_patterns` as an array with all rows (same check as Step 0).
+
+**Manual smoke test (golden path — Edit Word Modal):**
+
+1. Open **Edit Word Modal** for a word that has multiple senses.
+2. Verify Grammar Patterns collapsible card renders inside each sense card.
+3. Collapse and expand the Grammar Patterns card via header click.
+4. Click **Collapse All** — verify the Grammar Patterns cards also collapse (alongside Verb Morphology and Sense cards).
+5. Add a grammar pattern row, remove a non-last row, verify min-1 guard.
+6. Click **Re-enrich** — verify all grammar patterns from the LLM response are pre-populated (multi-row if the LLM returns multiple).
+7. Save — confirm PUT payload in Network tab: each sense carries all grammar pattern rows.
+
+**Edge cases:**
+
+- Sense with exactly one grammar pattern → Remove button disabled in both modals.
+- Sense with two+ grammar patterns → Remove button enabled for all; after removing one, the remaining row's field values are preserved correctly (no index collision between sense indices).
+- After Re-enrich, Grammar Patterns collapsible cards reset to expanded (same behaviour as Sense cards).
+
+---
+
+### Open Questions / Risks
+
+- [x] **Nested path silent failure:** An incorrect `name` path in `useFieldArray` yields `undefined` without a runtime error. **Resolved:** promoted to a mandatory Step 0 payload-shape check in Testing Strategy — verify the Network tab payload before any other UI smoke testing.
+- [x] **`max-h-500` class availability:** **Resolved:** `EditWordModal.tsx` already uses `max-h-500` on two existing collapsible sections (Verb Morphology at line 306, Sense cards at line 404) and those work in the current app. Tailwind v4's JIT generates `max-height: 125rem` for this class. No config change required — reuse the same class.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,3 @@
----
-name: Pull Request
-about: Describe code changes
-title: ""
-labels: ""
-assignees: ""
----
-
 ## Description
 
 The PR resolves the issue #<issue_number> by ...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.8] - 2026-06-16
+
+### Added
+
+- **Frontend**: New `GrammarPatternFields` React component — reusable sub-component that owns a nested `useFieldArray` for grammar patterns inside a sense loop; renders preposition input + case select per row with Add Grammar Pattern and Remove controls; Remove button is disabled at one row to enforce the min-1 constraint visually.
+
+### Changed
+
+- **Frontend**: `AddWordModal` grammar-pattern section replaced with `<GrammarPatternFields>` — users can now add and remove grammar pattern rows per sense in the word creation form.
+- **Frontend**: `EditWordModal` grammar-pattern section replaced with `<GrammarPatternFields>` wrapped in a collapsible Grammar Patterns card (same `max-h` CSS toggle pattern as Verb Morphology and Sense cards); `grammarPatternsCollapsed: boolean[]` state tracks per-sense collapse; "Collapse All" now also collapses grammar pattern cards.
+
 ## [0.4.7] - 2026-06-16
 
 ### Changed

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -12,8 +12,9 @@ A Next.js 16 single-page application that provides the user interface for Vademe
 - **`src/components/ReviewArea.tsx`** — Full-canvas review session container; owns `currentIndex` and `isTransitioning` state; fires `updateSenseReview` on difficulty selection then advances the card with a 150 ms opacity + `translate-x` CSS transition; renders `ReviewCompleteScreen` when the queue is exhausted; shows an empty-queue fallback
 - **`src/components/ReviewCompleteScreen.tsx`** — Session-end screen rendered when all cards in the review queue have been rated; two buttons to navigate back to the Vocabulary Area or Learning Area via `onNavigate`
 - **`src/components/SenseCard.tsx`** — Flashcard display for a single sense; three collapsible sections (Word Information, Verb Morphology, Sense Information); Verb Morphology rendered only when `category === "verb"`; four Difficulty Level buttons (Easy / Medium / Hard / Very Hard)
-- **`src/components/AddWordModal.tsx`** — Modal form for creating a new word entry; includes an "Enrich" button that calls the AI enrichment API to pre-populate fields
-- **`src/components/EditWordModal.tsx`** — Full edit form for updating word data (all fields including nested senses) with a delete action; opened by clicking a row in WordTable
+- **`src/components/GrammarPatternFields.tsx`** — Reusable sub-component that owns the nested `useFieldArray` for grammar patterns inside a sense; renders preposition input + case select per row with Add/Remove controls; Remove is disabled when only one row remains
+- **`src/components/AddWordModal.tsx`** — Modal form for creating a new word entry; includes an "Enrich" button that calls the AI enrichment API to pre-populate fields; uses `GrammarPatternFields` per sense for multi-row grammar pattern editing
+- **`src/components/EditWordModal.tsx`** — Full edit form for updating word data (all fields including nested senses) with a delete action; opened by clicking a row in WordTable; uses `GrammarPatternFields` per sense inside a collapsible Grammar Patterns card
 - **`src/components/WordTable.tsx`** — Displays the vocabulary as a clickable table; clicking a row opens EditWordModal
 - **`src/components/SearchBar.tsx`** — Debounced search input (300 ms default) that fires an `onSearch` callback when the user pauses typing
 - **`src/components/ThemeToggle.tsx`** — Toggles light/dark mode by manipulating the `dark` CSS class on `<html>` and persisting the choice in `localStorage`
@@ -30,6 +31,7 @@ A Next.js 16 single-page application that provides the user interface for Vademe
 - `<SenseCard sense onDifficultySelect>` — sense flashcard; `onDifficultySelect: (level: "Easy" | "Medium" | "Hard" | "VeryHard") => void`
 - `<AreaToggle area onAreaChange>` — pill toggle between `"vocabulary"` and `"learning"`; not rendered when `area === "review"`
 - `<SensesTable onStartReview>` — senses table with multi-select checkboxes and "Start Review" button; calls `onStartReview(selected: SenseWithWord[])` to hand off the review queue
+- `<GrammarPatternFields senseIndex control errors register>` — nested field-array block for grammar patterns; `senseIndex: number`, `control: Control<WordFormValues>`, `errors: FieldErrors<WordFormValues>`, `register: UseFormRegister<WordFormValues>`; used inside the sense loop of both modals
 - `<AddWordModal onWordAdded>` — button + modal to create a word; calls `onWordAdded()` after a successful save
 - `<EditWordModal word isOpen onClose onWordDeleted onWordUpdated>` — full edit form for all word fields including senses; calls `onWordUpdated` after a successful save and `onWordDeleted` after deletion
 - `<WordTable words onRefresh>` — renders the vocabulary table; calls `onRefresh()` after a deletion
@@ -61,7 +63,10 @@ A Next.js 16 single-page application that provides the user interface for Vademe
 
 - The backend base URL is hardcoded to `http://localhost:8000` in both `page.tsx` and `lib/api.ts`; no environment-variable abstraction exists yet.
 - Dark mode is initialised by an inline `<script>` in `layout.tsx` that runs before React hydrates, reading `localStorage.theme` and the system `prefers-color-scheme` preference. The `<html>` element has `suppressHydrationWarning` set.
-- `wordSchema` is the single source of truth for form validation — both `AddWordModal` and `EditWordModal` must use it; diverging will silently break backend contract alignment. The schema includes nested `senseSchema` with `min_length=1` enforced at the Zod layer.
+- `wordSchema` is the single source of truth for form validation — both `AddWordModal` and `EditWordModal` must use it; diverging will silently break backend contract alignment. The schema includes nested `senseSchema` with `min_length=1` enforced at the Zod layer, and `grammar_patterns: z.array(grammarPatternSchema).min(1)` mirroring the backend constraint.
+- Every sense must retain at least one grammar pattern — enforced at the Zod layer (`min(1)`) and in the UI via the disabled Remove button in `GrammarPatternFields`, with the backend HTTP 422 as the final guard.
+- `GrammarPatternFields` must not be called inside a `.map()` callback — it calls `useFieldArray` internally and must be rendered as a proper React component to comply with the Rules of Hooks.
+- New grammar pattern rows must be initialised with `preposition: null` (not `undefined`) to align with the backend `nullable` contract and the `GrammarPattern` TypeScript interface.
 - Without a search query, the word list is capped at 10 results (`?limit=10`); search results are uncapped.
 
 ## Out of scope
@@ -72,6 +77,12 @@ A Next.js 16 single-page application that provides the user interface for Vademe
 - **Backend persistence logic** — handled entirely by the FastAPI backend and PostgreSQL
 
 ## Changelog
+
+### 2026-06-16 (v0.4.8)
+
+- Added `GrammarPatternFields.tsx`: reusable sub-component encapsulating a nested `useFieldArray` for grammar patterns per sense; renders preposition input + case select per row with Add Grammar Pattern and Remove controls; Remove button is disabled when only one row remains; appends `{ preposition: null, case: "Akkusativ" }` to preserve the backend nullable contract.
+- Updated `AddWordModal.tsx`: replaced the inline grammar-pattern `.map()` block inside the sense loop with `<GrammarPatternFields>`, enabling multi-row grammar pattern editing per sense.
+- Updated `EditWordModal.tsx`: replaced the inline grammar-pattern `.map()` block with `<GrammarPatternFields>` wrapped in a collapsible card (`max-h` CSS toggle, `ChevronDown`/`ChevronUp` header, red error badge when collapsed with errors); added `grammarPatternsCollapsed: boolean[]` state synced via `useEffect` on `senseFields.length`; extended `handleCollapseAll` to also collapse grammar pattern cards.
 
 ### 2026-05-23 (v0.4.3)
 

--- a/frontend/src/components/AddWordModal.tsx
+++ b/frontend/src/components/AddWordModal.tsx
@@ -1,5 +1,6 @@
 import { enrichWord } from "@/lib/api";
 import { WordFormValues, wordSchema } from "@/lib/wordSchema";
+import GrammarPatternFields from "@/components/GrammarPatternFields";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { PlusCircle, Sparkles, Trash2 } from "lucide-react";
 import { useState } from "react";
@@ -282,35 +283,12 @@ export default function AddWordModal({ onWordAdded }: AddWordModalProps) {
                       </div>
 
                       {/* Grammar Patterns */}
-                      <div>
-                        <p className="text-xs font-medium text-forest-600 dark:text-forest-300 mb-1">
-                          Grammar Patterns
-                        </p>
-                        {(watchedSenses[sIdx]?.grammar_patterns ?? []).map(
-                          (_, gpIdx) => (
-                            <div key={gpIdx} className="flex gap-2 mt-1">
-                              <input
-                                {...register(
-                                  `senses.${sIdx}.grammar_patterns.${gpIdx}.preposition`,
-                                )}
-                                placeholder="Preposition (optional)"
-                                className={inputClass}
-                              />
-                              <select
-                                {...register(
-                                  `senses.${sIdx}.grammar_patterns.${gpIdx}.case`,
-                                )}
-                                className={inputClass}
-                              >
-                                <option value="Akkusativ">Akkusativ</option>
-                                <option value="Dativ">Dativ</option>
-                                <option value="Nominativ">Nominativ</option>
-                                <option value="Genitiv">Genitiv</option>
-                              </select>
-                            </div>
-                          ),
-                        )}
-                      </div>
+                      <GrammarPatternFields
+                        senseIndex={sIdx}
+                        control={control}
+                        errors={errors}
+                        register={register}
+                      />
 
                       {/* Example Sentences */}
                       <div>

--- a/frontend/src/components/EditWordModal.tsx
+++ b/frontend/src/components/EditWordModal.tsx
@@ -1,5 +1,6 @@
 import { enrichWord, updateWord } from "@/lib/api";
 import { WordFormValues, wordSchema } from "@/lib/wordSchema";
+import GrammarPatternFields from "@/components/GrammarPatternFields";
 import { Word } from "@/types/word";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { clsx } from "clsx";
@@ -65,6 +66,7 @@ export default function EditWordModal({
   const [enrichError, setEnrichError] = useState<string | null>(null);
   const [verbMorphologyCollapsed, setVerbMorphologyCollapsed] = useState(false);
   const [sensesCollapsed, setSensesCollapsed] = useState<boolean[]>([]);
+  const [grammarPatternsCollapsed, setGrammarPatternsCollapsed] = useState<boolean[]>([]);
 
   const {
     register,
@@ -93,6 +95,16 @@ export default function EditWordModal({
   // Re-enrich calls reset() which repopulates senseFields from zero, expanding all cards.
   useEffect(() => {
     setSensesCollapsed((prev) => {
+      if (senseFields.length > prev.length) {
+        return [...prev, ...Array(senseFields.length - prev.length).fill(false)];
+      }
+      return prev.slice(0, senseFields.length);
+    });
+  }, [senseFields.length]);
+
+  // Mirror pattern for per-sense grammar-pattern collapse state.
+  useEffect(() => {
+    setGrammarPatternsCollapsed((prev) => {
       if (senseFields.length > prev.length) {
         return [...prev, ...Array(senseFields.length - prev.length).fill(false)];
       }
@@ -131,6 +143,7 @@ export default function EditWordModal({
   const handleCollapseAll = (): void => {
     setVerbMorphologyCollapsed(true);
     setSensesCollapsed((prev) => prev.map(() => true));
+    setGrammarPatternsCollapsed((prev) => prev.map(() => true));
   };
 
   const handleDelete = async () => {
@@ -434,34 +447,47 @@ export default function EditWordModal({
                       </div>
 
                       {/* Grammar Patterns */}
-                      <div>
-                        <p className="text-xs font-medium text-forest-600 dark:text-forest-300 mb-1">
-                          Grammar Patterns
-                        </p>
-                        {(watchedSenses[sIdx]?.grammar_patterns ?? []).map(
-                          (_, gpIdx) => (
-                            <div key={gpIdx} className="flex gap-2 mt-1">
-                              <input
-                                {...register(
-                                  `senses.${sIdx}.grammar_patterns.${gpIdx}.preposition`,
-                                )}
-                                placeholder="Preposition (optional)"
-                                className={inputClass}
+                      <div className="border border-forest-200 dark:border-forest-600 rounded-lg p-3">
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setGrammarPatternsCollapsed((prev) =>
+                              prev.map((c, i) => (i === sIdx ? !c : c)),
+                            )
+                          }
+                          className="flex w-full items-center gap-2"
+                        >
+                          {grammarPatternsCollapsed[sIdx] ? (
+                            <ChevronDown className="w-3 h-3 text-forest-600 dark:text-forest-300" />
+                          ) : (
+                            <ChevronUp className="w-3 h-3 text-forest-600 dark:text-forest-300" />
+                          )}
+                          <span className="text-xs font-semibold text-forest-600 dark:text-forest-300 uppercase tracking-wide">
+                            Grammar Patterns
+                          </span>
+                          {!!errors.senses?.[sIdx]?.grammar_patterns &&
+                            grammarPatternsCollapsed[sIdx] && (
+                              <span
+                                className="ml-auto h-2 w-2 rounded-full bg-red-500"
+                                aria-label="Contains errors"
                               />
-                              <select
-                                {...register(
-                                  `senses.${sIdx}.grammar_patterns.${gpIdx}.case`,
-                                )}
-                                className={inputClass}
-                              >
-                                <option value="Akkusativ">Akkusativ</option>
-                                <option value="Dativ">Dativ</option>
-                                <option value="Nominativ">Nominativ</option>
-                                <option value="Genitiv">Genitiv</option>
-                              </select>
-                            </div>
-                          ),
-                        )}
+                            )}
+                        </button>
+                        <div
+                          className={clsx(
+                            "overflow-hidden transition-[max-height] duration-300",
+                            grammarPatternsCollapsed[sIdx] ? "max-h-0" : "max-h-500",
+                          )}
+                        >
+                          <div className="pt-2">
+                            <GrammarPatternFields
+                              senseIndex={sIdx}
+                              control={control}
+                              errors={errors}
+                              register={register}
+                            />
+                          </div>
+                        </div>
                       </div>
 
                       {/* Example Sentences */}

--- a/frontend/src/components/GrammarPatternFields.tsx
+++ b/frontend/src/components/GrammarPatternFields.tsx
@@ -1,0 +1,69 @@
+import { WordFormValues } from "@/lib/wordSchema";
+import { PlusCircle, Trash2 } from "lucide-react";
+import { Control, FieldErrors, UseFormRegister, useFieldArray } from "react-hook-form";
+
+interface GrammarPatternFieldsProps {
+  senseIndex: number;
+  control: Control<WordFormValues>;
+  errors: FieldErrors<WordFormValues>;
+  register: UseFormRegister<WordFormValues>;
+}
+
+const inputClass =
+  "text-forest-800 dark:text-forest-100 dark:bg-forest-900 border border-forest-300 dark:border-forest-600 w-full p-2 rounded-md focus:outline-none focus:ring-2 focus:ring-forest-500 dark:focus:ring-forest-400";
+
+export default function GrammarPatternFields({
+  senseIndex,
+  control,
+  errors,
+  register,
+}: GrammarPatternFieldsProps) {
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: `senses.${senseIndex}.grammar_patterns`,
+  });
+
+  return (
+    <div className="space-y-1">
+      {fields.map((gpField, gpIdx) => (
+        <div key={gpField.id} className="flex gap-2 items-center mt-1">
+          <input
+            {...register(`senses.${senseIndex}.grammar_patterns.${gpIdx}.preposition`)}
+            placeholder="Preposition (optional)"
+            className={inputClass}
+          />
+          <select
+            {...register(`senses.${senseIndex}.grammar_patterns.${gpIdx}.case`)}
+            className={inputClass}
+          >
+            <option value="Akkusativ">Akkusativ</option>
+            <option value="Dativ">Dativ</option>
+            <option value="Nominativ">Nominativ</option>
+            <option value="Genitiv">Genitiv</option>
+          </select>
+          <button
+            type="button"
+            onClick={() => remove(gpIdx)}
+            disabled={fields.length === 1}
+            className="text-red-400 hover:text-red-600 disabled:opacity-30 disabled:cursor-not-allowed shrink-0"
+          >
+            <Trash2 className="w-3 h-3" />
+          </button>
+        </div>
+      ))}
+      {errors.senses?.[senseIndex]?.grammar_patterns &&
+        !Array.isArray(errors.senses[senseIndex].grammar_patterns) && (
+          <p className="text-red-500 text-xs">
+            {(errors.senses[senseIndex].grammar_patterns as { message?: string })?.message}
+          </p>
+        )}
+      <button
+        type="button"
+        onClick={() => append({ preposition: null, case: "Akkusativ" })}
+        className="text-xs text-forest-600 dark:text-forest-300 hover:text-forest-800 dark:hover:text-forest-100 flex items-center gap-1 mt-1"
+      >
+        <PlusCircle className="w-3 h-3" /> Add Grammar Pattern
+      </button>
+    </div>
+  );
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vademecum-germanicum"
-version = "0.4.7"
+version = "0.4.8"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Description

The PR resolves the issue #77 by adding the multi grammar pattern in the UI.

## Changelog

### Added

- **Frontend**: New `GrammarPatternFields` React component — reusable sub-component that owns a nested `useFieldArray` for grammar patterns inside a sense loop; renders preposition input + case select per row with Add Grammar Pattern and Remove controls; Remove button is disabled at one row to enforce the min-1 constraint visually.

### Changed

- **Frontend**: `AddWordModal` grammar-pattern section replaced with `<GrammarPatternFields>` — users can now add and remove grammar pattern rows per sense in the word creation form.
- **Frontend**: `EditWordModal` grammar-pattern section replaced with `<GrammarPatternFields>` wrapped in a collapsible Grammar Patterns card (same `max-h` CSS toggle pattern as Verb Morphology and Sense cards); `grammarPatternsCollapsed: boolean[]` state tracks per-sense collapse; "Collapse All" now also collapses grammar pattern cards.

## Checklist

### Mandatory

- [x] The title of the Pull Request starts with the JIRA ticket number (if provided)
- [x] The title of the Pull Request must reflect the corresponding issue title
- [x] It has to have a `Description` section, specifying which is the `#issue` it's resolving and how
- [x] It has to have a `Changelog` section, reporting what has been changed in the corresponding issue
- [x] The project version must have been updated

### Optional

- [x] Update the Wiki
- [x] Update the `README.md`
- [x] Update the `CHANGELOG.md`
