### PR TITLE
Feat/85 backend duplicate check support

### DIFF
--- a/.claude/9-check-word-already-exist/85-backend-duplicate-check-support.md
+++ b/.claude/9-check-word-already-exist/85-backend-duplicate-check-support.md
@@ -1,0 +1,181 @@
+# #85: Backend Duplicate-Check Support
+
+**GitHub Issue:** [#85 — Backend Duplicate-Check Support](https://github.com/Volscente/vademecum-germanicum/issues/85)
+**GitHub Milestone:** [9-check-word-already-exist](https://github.com/Volscente/vademecum-germanicum/milestone/11)
+**Notion page:** [9 — Check word already existing](https://app.notion.com/p/9-Check-word-already-existing-3925cc6c0f0780cb929ffeeee7632263)
+
+---
+
+## Technical Scope
+
+**In scope:**
+
+- `migrations/add_unique_word_constraint.sql` — New migration: `ALTER TABLE words ADD CONSTRAINT words_word_key UNIQUE (word);`
+- `backend/src/backend/main.py` — Catch `IntegrityError` on `POST /words/` and return HTTP 409
+- `frontend/src/lib/api.ts` — Add `checkWordExists(word: string): Promise<boolean>` helper
+
+**Out of scope:**
+
+- Fuzzy / phonetic duplicate matching — exact (case-sensitive) only
+- Duplicate detection in `EditWordModal` — creation flow only
+- New backend endpoint — the existing `GET /words/` endpoint is reused
+- Frontend UI wiring (`AddWordModal` state, debounce, button gating) — TASK-2 and TASK-3
+
+---
+
+## Architecture
+
+```txt
+User types in AddWordModal (TASK-2)
+        │
+        ▼
+checkWordExists(word: string)              [frontend/src/lib/api.ts]
+        │  GET /words/?search=<word>&limit=500
+        │
+        ▼
+GET /words/ handler                        [backend/src/backend/main.py]
+        │  returns Word[] (existing endpoint, unchanged)
+        │
+        ▼
+client-side filter: entry.word === word    [checkWordExists]
+        │  → boolean (true = duplicate found)
+        │
+        ▼
+isDuplicate state in AddWordModal          (wired in TASK-2)
+
+── Race-condition path (fast submission before debounce fires) ──
+        │
+        ▼
+POST /words/                               [backend/src/backend/main.py]
+        │  DB UNIQUE (word) constraint violated
+        │
+        ▼
+SQLAlchemy raises IntegrityError
+        │
+        ▼
+409 HTTPException("A word with this spelling already exists.")
+        │
+        ▼
+Caught in onSubmit → setError("word", …)  (wired in TASK-2)
+```
+
+### Why case-sensitive constraint with case-insensitive client filter
+
+The PostgreSQL `UNIQUE (word)` constraint is case-sensitive, which is correct for German: "laufen" (verb) and "Laufen" (nominalised noun) are distinct orthographic entries that must coexist. The `checkWordExists` helper filters client-side using `entry.word.toLowerCase() === word.toLowerCase()` to give the user a proactive warning even when capitalisation differs — it is a UX guard, not a semantic one. The DB constraint is the authoritative uniqueness gate.
+
+---
+
+## Tech Stack
+
+No new packages required.
+
+---
+
+## Implementation Details
+
+### Modules / Files
+
+| File                                          | Action | Description                                                            |
+| --------------------------------------------- | ------ | ---------------------------------------------------------------------- |
+| `migrations/add_unique_word_constraint.sql`   | Create | Plain `ALTER TABLE` adding `UNIQUE (word)` to the `words` table        |
+| `backend/src/backend/main.py`                 | Edit   | Catch `IntegrityError` in `POST /words/` handler; return HTTP 409      |
+| `frontend/src/lib/api.ts`                     | Edit   | Add `checkWordExists` alongside existing `enrichWord`, `updateWord` etc |
+
+---
+
+### Key Functions
+
+**`checkWordExists` — TypeScript, `frontend/src/lib/api.ts`**
+
+```typescript
+/**
+ * Check whether a word already exists in the vocabulary table.
+ *
+ * Calls GET /words/?search=<word>&limit=500 and filters the response for a
+ * case-insensitive exact match on the `word` field. The search endpoint does
+ * substring matching, so client-side filtering is required to avoid false
+ * positives (e.g. "laufen" matching "anlaufen").
+ *
+ * @param word - The word string to check, as typed by the user.
+ * @returns Promise resolving to true if an exact (case-insensitive) match
+ *          exists, false otherwise.
+ */
+async function checkWordExists(word: string): Promise<boolean>
+```
+
+**`POST /words/` handler change — Python, `backend/src/backend/main.py`**
+
+```python
+def create_word(word: WordCreate, db: Session = Depends(get_db)) -> WordRead:
+    """Create a new word with its full sense graph.
+
+    Unchanged behaviour for valid payloads. Adds an IntegrityError catch so
+    that a UNIQUE (word) constraint violation on the `words` table returns
+    HTTP 409 instead of propagating as an unhandled 500.
+
+    Args:
+        word: Validated WordCreate payload including at least one Sense.
+        db: SQLAlchemy session injected by FastAPI dependency.
+
+    Returns:
+        WordRead representation of the newly created word.
+
+    Raises:
+        HTTPException(409): When the submitted word value already exists in
+            the `words` table (constraint: words_word_key UNIQUE (word)).
+        HTTPException(422): When the payload fails Pydantic validation
+            (existing behaviour, unchanged).
+    """
+```
+
+---
+
+### CLI Parameters
+
+Not applicable — this task has no CLI surface.
+
+---
+
+### Data Models / Schemas
+
+No new models or schemas. The existing `WordCreate`, `WordRead`, and `Word` (TypeScript interface) are unchanged. The `checkWordExists` response is a plain `boolean`.
+
+---
+
+### Testing Strategy
+
+**Backend tests** (`backend/tests/test_words.py`):
+
+- `test_create_word_duplicate_returns_409` — POST the same word twice; assert the second response is HTTP 409 with `detail` matching `"A word with this spelling already exists."`
+- `test_create_word_case_sensitive_duplicate` — POST "Laufen" then POST "laufen"; assert both succeed (HTTP 201), confirming the constraint is case-sensitive and the two entries are treated as distinct
+
+**Frontend tests** (manual, using `just dev`):
+
+```bash
+# With the stack running, open the browser console and call:
+fetch("http://localhost:8000/words/?search=Haus&limit=500")
+  .then(r => r.json())
+  .then(words => console.log(words.some(w => w.word.toLowerCase() === "haus")))
+# Expect: true (if "Haus" exists), false otherwise
+```
+
+**Migration verification:**
+
+```bash
+just run_migration   # applies add_unique_word_constraint.sql
+# Then in psql:
+\d words             # confirm words_word_key UNIQUE (word) appears in indexes
+```
+
+**Edge cases:**
+
+- Empty `word` string passed to `checkWordExists` → return `false` immediately without making a network call (guard at function entry)
+- `GET /words/` returns an empty array → `checkWordExists` returns `false` (no match)
+- Vocabulary exceeds 500 words sharing a substring → `limit=500` mitigates the risk; acceptable for current scale
+
+---
+
+### Open Questions / Risks
+
+- [ ] **`limit=500` sufficiency:** If the vocabulary grows beyond 500 entries sharing a common substring, `checkWordExists` may miss the exact match. **Target:** revisit when word count exceeds 400 (add an exact-match query parameter to the backend as a follow-up)
+- [ ] **Migration is irreversible without a companion `DROP CONSTRAINT` script:** if the constraint needs to be removed (e.g. to allow duplicates during a data import), a rollback script must be written manually. **Target:** acceptable for now; document in `migrations/README.md` if one is created

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.10] - 2026-07-15
+
+### Added
+
+- **Infrastructure**: New `migrations/add_unique_word_constraint.sql` — idempotent `DO $$` block that adds `UNIQUE (word)` constraint (`words_word_key`) to the `words` table; apply with `just run_migration`.
+- **Backend**: `POST /words/` now returns HTTP 409 with `"A word with this spelling already exists."` when the submitted word value violates the `words_word_key` unique constraint.
+- **Backend**: `UniqueConstraint("word", name="words_word_key")` declared in the `Word` ORM model so `create_all` enforces uniqueness on fresh database instances.
+- **Frontend**: `checkWordExists(word: string): Promise<boolean>` helper in `api.ts` — calls `GET /words/?search=<word>&limit=500` and returns `true` if any result is an exact case-insensitive match on the `word` field; returns `false` immediately for an empty input.
+- **Tests**: `test_create_word_duplicate_returns_409` — verifies the second POST of the same word returns HTTP 409 with the correct detail message.
+- **Tests**: `test_create_word_case_sensitive_duplicate` — verifies "laufen" and "Laufen" are treated as distinct entries (constraint is case-sensitive).
+- **Tests**: `apply_migrations` session-scoped fixture in `database_management.py` — idempotently applies the `words_word_key` constraint to the running `vademecum_db` container before the test session starts.
+
 ## [0.4.9] - 2026-06-16
 
 ### Changed

--- a/backend/README.md
+++ b/backend/README.md
@@ -18,8 +18,8 @@ A FastAPI application that serves as the data and AI layer for Vademecum Germani
 
 - `GET /` — health check; returns a welcome message
 - `POST /words/enrich` — accepts `{"word": str}`, returns `WordEnrichment` with LLM-populated metadata including a `senses` array (min 1) each carrying `grammar_patterns` and `example_sentences`
-- `POST /words/` — creates a new word with its full sense graph; accepts `WordCreate` (including `senses: list[SenseCreate]`), returns `WordRead`
-- `GET /words/?skip&limit&search` — lists words with optional case-insensitive search on `word` and `translation`; each word embeds its full sense graph
+- `POST /words/` — creates a new word with its full sense graph; accepts `WordCreate` (including `senses: list[SenseCreate]`), returns `WordRead`; returns HTTP 409 if the `word` value already exists (enforced by `words_word_key UNIQUE` constraint)
+- `GET /words/?skip&limit&search` — lists words with optional case-insensitive search on `word` and `translation`; each word embeds its full sense graph; used by the frontend as the duplicate-check data source
 - `PUT /words/{word_id}` — partially updates a word; accepts `WordUpdate` (all fields optional, including `senses`); when `senses` is provided it replaces the existing sense list; returns `WordRead`
 - `DELETE /words/{word_id}` — removes a word and all its senses (cascade); returns HTTP 204
 - `GET /senses/` — returns all senses with parent word fields embedded (`word`, `translation`, `gender`, `category`); response schema `SenseWithWordRead`
@@ -51,6 +51,7 @@ A FastAPI application that serves as the data and AI layer for Vademecum Germani
 - The enrichment agent is instantiated per-request (no singleton); this is intentional to pick up env var changes without a restart, but adds per-call overhead.
 - DB tables are created at import time via `models.Base.metadata.create_all`; schema migrations are not managed (no Alembic). Breaking schema changes require a manual SQL migration script (see `migrations/` and `just run_migration`).
 - `difficulty_level` defaults to `"Medium"` for all new senses; `last_reviewed_at` starts `NULL`. Both are set/stamped server-side only — never trusted from the client.
+- `words.word` is subject to a `UNIQUE` constraint (`words_word_key`). The constraint is case-sensitive — "laufen" and "Laufen" are distinct entries. `POST /words/` returns HTTP 409 on violation.
 - `last_reviewed_at` is always written using `datetime.now(timezone.utc)`; `datetime.utcnow()` is deprecated and must not be used.
 
 ## Out of scope
@@ -69,6 +70,12 @@ A FastAPI application that serves as the data and AI layer for Vademecum Germani
 - `SenseReviewUpdate` and `SenseWithWordRead` schemas added to `schemas.py`; `SenseRead` extended with the two new fields.
 - `GET /senses/` and `PUT /senses/{sense_id}/review` endpoints implemented in `main.py`.
 - `migrations/add_sense_review_columns.sql` — idempotent `ALTER TABLE` script; apply with `just run_migration`.
+
+### 2026-07-15 (v0.4.10)
+
+- Added `UNIQUE (word)` constraint to the `words` table via `migrations/add_unique_word_constraint.sql` (idempotent — uses a DO block guard).
+- `POST /words/` now catches `IntegrityError` and returns HTTP 409 with `"A word with this spelling already exists."` when the constraint is violated.
+- `UniqueConstraint("word", name="words_word_key")` added to the `Word` ORM model so `create_all` creates the constraint on fresh databases.
 
 ### 2026-05-09 (v0.3.1)
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "backend"
-version = "0.4.9"
+version = "0.4.10"
 description = "Add your description here"
 readme = "README.md"
 authors = [{ name = "Simone Porreca", email = "porrecasimone@gmail.com" }]

--- a/backend/src/backend/main.py
+++ b/backend/src/backend/main.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timezone
 
 from fastapi import Depends, FastAPI, HTTPException
+from sqlalchemy.exc import IntegrityError
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy import or_
 from sqlalchemy.orm import Session, selectinload
@@ -190,6 +191,8 @@ def create_word(word: schemas.WordCreate, db: Session = Depends(get_db)) -> mode
         The persisted `Word` ORM instance, serialized as `WordRead` by FastAPI.
 
     Raises:
+        HTTPException (409): If the word value already exists in the `words` table
+                             (constraint: words_word_key UNIQUE (word)).
         HTTPException (422): Raised automatically by FastAPI/Pydantic if
                              validation constraints are violated (e.g., empty senses list).
     """
@@ -197,8 +200,14 @@ def create_word(word: schemas.WordCreate, db: Session = Depends(get_db)) -> mode
     for sense_data in word.senses:
         db_word.senses.append(_build_sense_orm(sense_data))
 
-    db.add(db_word)
-    db.commit()
+    try:
+        db.add(db_word)
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=409, detail="A word with this spelling already exists."
+        )
     return _load_word_with_senses(db, db_word.id)
 
 

--- a/backend/src/backend/models.py
+++ b/backend/src/backend/models.py
@@ -4,7 +4,7 @@ SQLAlchemy ORM models for the database Data Schema.
 
 import enum
 
-from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, JSON, String, func
+from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, JSON, String, UniqueConstraint, func
 from sqlalchemy.orm import declarative_base, relationship
 
 Base = declarative_base()
@@ -129,6 +129,7 @@ class Word(Base):
     """
 
     __tablename__ = "words"
+    __table_args__ = (UniqueConstraint("word", name="words_word_key"),)
 
     id = Column(Integer, primary_key=True, index=True)
 

--- a/backend/tests/fixtures/database_management.py
+++ b/backend/tests/fixtures/database_management.py
@@ -3,11 +3,38 @@ Database management fixtures.
 """
 
 import pytest
-from sqlalchemy import event
+from sqlalchemy import event, text
 from sqlalchemy.orm import Session
 from backend.database import engine, get_db
 from backend.main import app
 from fastapi.testclient import TestClient
+
+
+@pytest.fixture(scope="session", autouse=True)
+def apply_migrations():
+    """Ensure schema constraints from SQL migrations are present in the test DB.
+
+    create_all() only creates tables that don't exist yet — it never alters
+    existing tables. This fixture idempotently applies migrations that add
+    constraints so that constraint-dependent tests work against the live
+    vademecum_db container regardless of when the container was first created.
+    """
+    with engine.connect() as conn:
+        conn.execute(
+            text(
+                """
+                DO $$
+                BEGIN
+                    IF NOT EXISTS (
+                        SELECT 1 FROM pg_constraint WHERE conname = 'words_word_key'
+                    ) THEN
+                        ALTER TABLE words ADD CONSTRAINT words_word_key UNIQUE (word);
+                    END IF;
+                END $$;
+                """
+            )
+        )
+        conn.commit()
 
 
 @pytest.fixture(scope="session")

--- a/backend/tests/test_words.py
+++ b/backend/tests/test_words.py
@@ -217,3 +217,30 @@ def test_update_word_without_senses_preserves_existing(client, valid_word_payloa
     data = response.json()
     assert data["translation"] == "Extra charge"
     assert len(data["senses"]) == 1
+
+
+def test_create_word_duplicate_returns_409(client, valid_word_payload):
+    """
+    Ensure a second POST with the same word value returns HTTP 409.
+    """
+    client.post("/words/", json=valid_word_payload)
+    response = client.post("/words/", json=valid_word_payload)
+    assert response.status_code == 409
+    assert response.json()["detail"] == "A word with this spelling already exists."
+
+
+def test_create_word_case_sensitive_duplicate(client, valid_word_payload):
+    """
+    Ensure that words differing only in capitalisation are treated as distinct entries.
+
+    The UNIQUE (word) constraint is case-sensitive, reflecting German orthographic
+    convention where e.g. "laufen" (verb) and "Laufen" (nominalised noun) coexist.
+    """
+    lower_payload = {**valid_word_payload, "word": "laufen"}
+    upper_payload = {**valid_word_payload, "word": "Laufen"}
+
+    response_lower = client.post("/words/", json=lower_payload)
+    response_upper = client.post("/words/", json=upper_payload)
+
+    assert response_lower.status_code == 200
+    assert response_upper.status_code == 200

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -38,6 +38,7 @@ A Next.js 16 single-page application that provides the user interface for Vademe
 - `<SearchBar onSearch placeholder? delay?>` — debounced search field; fires `onSearch(value)` after the configured delay
 - `<ThemeToggle />` — self-contained dark/light mode toggle; no props
 - `enrichWord(word: string): Promise<WordEnrichment>` — calls `POST /words/enrich` and returns AI-generated sense-based word metadata
+- `checkWordExists(word: string): Promise<boolean>` — calls `GET /words/?search=<word>&limit=500` and returns `true` if any result is an exact case-insensitive match; returns `false` immediately for an empty input string
 - `updateWord(wordId: number, data: WordFormValues): Promise<Word>` — calls `PUT /words/{id}` and returns the updated word with full sense graph
 - `getSenses(): Promise<SenseWithWord[]>` — calls `GET /senses/` and returns all senses with parent word fields embedded
 - `updateSenseReview(senseId, difficultyLevel): Promise<Sense>` — calls `PUT /senses/{id}/review` to persist a difficulty rating and stamp `last_reviewed_at`
@@ -77,6 +78,10 @@ A Next.js 16 single-page application that provides the user interface for Vademe
 - **Backend persistence logic** — handled entirely by the FastAPI backend and PostgreSQL
 
 ## Changelog
+
+### 2026-07-15 (v0.4.10)
+
+- Added `checkWordExists(word: string): Promise<boolean>` to `api.ts` — calls `GET /words/?search=<word>&limit=500` and filters client-side for a case-insensitive exact match; returns `false` immediately for an empty input.
 
 ### 2026-06-16 (v0.4.9)
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -97,3 +97,34 @@ export async function updateWord(
 
   return response.json() as Promise<Word>;
 }
+
+/**
+ * Check whether a word already exists in the vocabulary table.
+ *
+ * Calls GET /words/?search=<word>&limit=500 and filters the response for a
+ * case-insensitive exact match on the `word` field. The search endpoint does
+ * substring matching, so client-side filtering is required to avoid false
+ * positives (e.g. "laufen" matching "anlaufen").
+ *
+ * @param word - The word string to check, as typed by the user.
+ * @returns Promise resolving to true if an exact (case-insensitive) match
+ *          exists, false otherwise.
+ */
+export async function checkWordExists(word: string): Promise<boolean> {
+  if (!word) {
+    return false;
+  }
+
+  const response = await fetch(
+    `http://localhost:8000/words/?search=${encodeURIComponent(word)}&limit=500`,
+  );
+
+  if (!response.ok) {
+    throw new Error(`Duplicate check failed: ${response.status}`);
+  }
+
+  const words = (await response.json()) as Word[];
+  return words.some(
+    (entry) => entry.word.toLowerCase() === word.toLowerCase(),
+  );
+}

--- a/justfile
+++ b/justfile
@@ -52,11 +52,12 @@ run_tests: check_root
 run_frontend: check_root
     cd frontend && npm run dev
 
-# Apply the sense review columns migration to the running PostgreSQL container
-# Run order: just run_backend_recreate first (starts all containers), then just run_migration
-run_migration: check_root
-    docker-compose exec db psql -U $POSTGRES_USER -d $POSTGRES_DB \
-        -f /dev/stdin < migrations/add_sense_review_columns.sql
+# Apply a SQL migration to the running PostgreSQL container
+# Usage: just run_migration <path/to/migration.sql>
+# Example: just run_migration migrations/add_unique_word_constraint.sql
+run_migration file: check_root
+    docker-compose exec -T db psql -U $POSTGRES_USER -d $POSTGRES_DB \
+        -f /dev/stdin < {{file}}
 
 # Empty the words table — use before applying enum changes that break existing data (DESTRUCTIVE)
 empty_words: check_root

--- a/migrations/add_unique_word_constraint.sql
+++ b/migrations/add_unique_word_constraint.sql
@@ -1,0 +1,8 @@
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'words_word_key'
+    ) THEN
+        ALTER TABLE words ADD CONSTRAINT words_word_key UNIQUE (word);
+    END IF;
+END $$;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vademecum-germanicum"
-version = "0.4.9"
+version = "0.4.10"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Description

The PR resolves the issue #85  by adding the word uniqueness constraint.

## Changelog

### Added

- **Infrastructure**: New `migrations/add_unique_word_constraint.sql` — idempotent `DO $$` block that adds `UNIQUE (word)` constraint (`words_word_key`) to the `words` table; apply with `just run_migration`.
- **Backend**: `POST /words/` now returns HTTP 409 with `"A word with this spelling already exists."` when the submitted word value violates the `words_word_key` unique constraint.
- **Backend**: `UniqueConstraint("word", name="words_word_key")` declared in the `Word` ORM model so `create_all` enforces uniqueness on fresh database instances.
- **Frontend**: `checkWordExists(word: string): Promise<boolean>` helper in `api.ts` — calls `GET /words/?search=<word>&limit=500` and returns `true` if any result is an exact case-insensitive match on the `word` field; returns `false` immediately for an empty input.
- **Tests**: `test_create_word_duplicate_returns_409` — verifies the second POST of the same word returns HTTP 409 with the correct detail message.
- **Tests**: `test_create_word_case_sensitive_duplicate` — verifies "laufen" and "Laufen" are treated as distinct entries (constraint is case-sensitive).
- **Tests**: `apply_migrations` session-scoped fixture in `database_management.py` — idempotently applies the `words_word_key` constraint to the running `vademecum_db` container before the test session starts.

## Checklist

### Mandatory

- [x] The title of the Pull Request starts with the JIRA ticket number (if provided)
- [x] The title of the Pull Request must reflect the corresponding issue title
- [x] It has to have a `Description` section, specifying which is the `#issue` it's resolving and how
- [x] It has to have a `Changelog` section, reporting what has been changed in the corresponding issue
- [x] The project version must have been updated

### Optional

- [x] Update the Wiki
- [x] Update the `README.md`
- [x] Update the `CHANGELOG.md`
